### PR TITLE
fix: restore default locale

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,7 @@ error_reporting(E_ALL & ~E_USER_DEPRECATED);
 
 chdir(dirname(__DIR__));
 
+ini_set('intl.default_locale', 'en_GB');
 date_default_timezone_set('Europe/London');
 
 // Decline static file requests back to the PHP built-in webserver


### PR DESCRIPTION
## Description

Restore the setting of default locale.

This _should_ be set on the server running the code in the `ini` but this is easier and can be removed once the VOL application moves to containers.