### PR TITLE
fix: Add Conviction button not working due to incorrect annotation on…

### DIFF
--- a/module/Olcs/src/Form/Model/Fieldset/Offence.php
+++ b/module/Olcs/src/Form/Model/Fieldset/Offence.php
@@ -95,7 +95,7 @@ class Offence extends Base
      *     "use_groups": true
      * })
      * @Form\Filter("Common\Filter\NullToArray")
-     * @Form\Validation({"name":"NotEmpty", "options": {"array"}})
+     * @Form\Validator("NotEmpty", options={"array"})
      */
     public $convictionCategory = null;
 


### PR DESCRIPTION
… Offence form.

## Description

Fix annotation causing broken Add Conviction button on Cases/Convictions page

VOL-4856

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
