### PR TITLE
fix: remove slash from `service_name` in `Form\Options`

### DIFF
--- a/module/Olcs/src/Form/Model/Fieldset/PublicInquiryHearingFields.php
+++ b/module/Olcs/src/Form/Model/Fieldset/PublicInquiryHearingFields.php
@@ -258,7 +258,7 @@ class PublicInquiryHearingFields extends Base
      * @Form\Options({
      *     "label": "Definition",
      *     "disable_inarray_validator": false,
-     *     "service_name": "\Olcs\Service\Data\PublicInquiryDefinition",
+     *     "service_name": "Olcs\Service\Data\PublicInquiryDefinition",
      *     "use_groups": true,
      *     "empty_option": "Add definition option"
      * })

--- a/module/Olcs/src/Form/Model/Fieldset/PublicInquiryRegisterDecisionMain.php
+++ b/module/Olcs/src/Form/Model/Fieldset/PublicInquiryRegisterDecisionMain.php
@@ -147,7 +147,7 @@ class PublicInquiryRegisterDecisionMain
      * @Form\Options({
      *     "label": "Definition",
      *     "disable_inarray_validator": false,
-     *     "service_name": "\Olcs\Service\Data\PublicInquiryDefinition",
+     *     "service_name": "Olcs\Service\Data\PublicInquiryDefinition",
      *     "use_groups": true,
      *     "empty_option": "Add definition option"
      * })

--- a/module/Olcs/src/Form/Model/Fieldset/PublicInquiryRegisterTmDecision.php
+++ b/module/Olcs/src/Form/Model/Fieldset/PublicInquiryRegisterTmDecision.php
@@ -96,7 +96,7 @@ class PublicInquiryRegisterTmDecision extends CaseBase
      * @Form\Options({
      *     "label": "Definition",
      *     "disable_inarray_validator": false,
-     *     "service_name": "\Olcs\Service\Data\PublicInquiryDefinition",
+     *     "service_name": "Olcs\Service\Data\PublicInquiryDefinition",
      *     "use_groups": true,
      *     "empty_option": "Add definition option"
      * })


### PR DESCRIPTION
## Description

Removes the prepended slash from `service_name` in `Form\Options`.

Related issue: https://dvsa.atlassian.net/browse/VOL-4864

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
