### PR TITLE
chore: bump `olcs-transfer` to `5.0.0-beta.8`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4296,16 +4296,16 @@
         },
         {
             "name": "olcs/olcs-transfer",
-            "version": "5.0.0-beta.7",
+            "version": "5.0.0-beta.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-transfer.git",
-                "reference": "5ba7b5279ecb96cbe545d95587c503caba6c38a0"
+                "reference": "9b20f1f18e02c42775e85b87ed362765a2177ed3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/5ba7b5279ecb96cbe545d95587c503caba6c38a0",
-                "reference": "5ba7b5279ecb96cbe545d95587c503caba6c38a0",
+                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/9b20f1f18e02c42775e85b87ed362765a2177ed3",
+                "reference": "9b20f1f18e02c42775e85b87ed362765a2177ed3",
                 "shasum": ""
             },
             "require": {
@@ -4345,9 +4345,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "OLCS Transfer",
             "support": {
-                "source": "https://github.com/dvsa/olcs-transfer/tree/5.0.0-beta.7"
+                "source": "https://github.com/dvsa/olcs-transfer/tree/5.0.0-beta.8"
             },
-            "time": "2024-01-16T11:11:04+00:00"
+            "time": "2024-01-25T22:35:27+00:00"
         },
         {
             "name": "olcs/olcs-utils",


### PR DESCRIPTION
## Description

Bump `olcs-transfer` to `5.0.0-beta.8`.