### PR TITLE
fix: fix visibility of table filters

### DIFF
--- a/module/Olcs/src/Controller/AbstractController.php
+++ b/module/Olcs/src/Controller/AbstractController.php
@@ -104,6 +104,6 @@ class AbstractController extends LaminasAbstractActionController
      */
     public function setTableFilters($filters)
     {
-        $this->viewHelperManager->get('placeholder')->getContainer('tableFilters')->set($filters);
+        $this->placeholder()->setPlaceholder('tableFilters', $filters);
     }
 }

--- a/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingTasksController.php
+++ b/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingTasksController.php
@@ -50,7 +50,6 @@ class LicenceProcessingTasksController extends AbstractLicenceProcessingControll
      */
     protected function getTaskForm(array $filters = [])
     {
-        $this->placeholder()->setPlaceholder('tableFilters', $this->traitGetTaskForm($filters)
-            ->remove('showTasks'));
+        return $this->traitGetTaskForm($filters)->remove('showTasks');
     }
 }


### PR DESCRIPTION
## Description

The view was trying to retrieve table filters from two different placeholder instances.

Related issue: https://dvsa.atlassian.net/browse/VOL-4897

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
