### PR TITLE
fix: Licence data service duplicated in service manager causing multi…

### DIFF
--- a/module/Olcs/config/module.config.php
+++ b/module/Olcs/config/module.config.php
@@ -704,7 +704,6 @@ return array(
             DataService\IrhpPermitPrintRangeType::class => DataService\IrhpPermitPrintRangeTypeFactory::class,
             DataService\IrhpPermitPrintStock::class => DataService\IrhpPermitPrintStockFactory::class,
             DataService\IrhpPermitPrintType::class => CommonDataService\AbstractDataServiceFactory::class,
-            DataService\Licence::class => DataService\LicenceFactory::class,
             DataService\OperatingCentresForInspectionRequest::class => DataService\OperatingCentresForInspectionRequestFactory::class,
             DataService\PaymentType::class => CommonDataService\RefDataFactory::class,
             DataService\PresidingTc::class => CommonDataService\AbstractDataServiceFactory::class,

--- a/module/Olcs/src/Controller/Factory/Operator/Cases/UnlicensedCasesOperatorControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/Cases/UnlicensedCasesOperatorControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator\Cases;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -34,7 +35,7 @@ class UnlicensedCasesOperatorControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
 

--- a/module/Olcs/src/Controller/Factory/Operator/Docs/OperatorDocsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/Docs/OperatorDocsControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator\Docs;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -36,7 +37,7 @@ class OperatorDocsControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
         $docSubCategoryDataService = $container->get(DocumentSubCategory::class);

--- a/module/Olcs/src/Controller/Factory/Operator/HistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/HistoryControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -35,7 +36,7 @@ class HistoryControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
 

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorBusinessDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorBusinessDetailsControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -37,7 +38,7 @@ class OperatorBusinessDetailsControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
         $translationHelper = $container->get(TranslationHelperService::class);

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -34,7 +35,7 @@ class OperatorControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
 

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorFeesControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorFeesControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -38,7 +39,7 @@ class OperatorFeesControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
         $translationHelper = $container->get(TranslationHelperService::class);

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorProcessingTasksControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorProcessingTasksControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -35,7 +36,7 @@ class OperatorProcessingTasksControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
         $subCategoryDataService = $container->get(SubCategory::class);

--- a/module/Olcs/src/Controller/Factory/Operator/UnlicensedBusinessDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/UnlicensedBusinessDetailsControllerFactory.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller\Factory\Operator;
 
 use Common\Service\Cqrs\Command\CommandService;
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\DateHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -36,7 +37,7 @@ class UnlicensedBusinessDetailsControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $licenceDataService = $container->get(Licence::class);
+        $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
         $navigation = $container->get('Navigation');
         $translationHelper = $container->get(TranslationHelperService::class);

--- a/module/Olcs/src/Controller/Operator/OperatorController.php
+++ b/module/Olcs/src/Controller/Operator/OperatorController.php
@@ -280,17 +280,14 @@ class OperatorController extends AbstractController implements OperatorControlle
             $data = ['fromOperatorName' => $organisationData['name']];
         }
 
-
         $formHelper = $this->formHelper;
 
         /* @var $form \Common\Form\Form */
         $form = $formHelper->createForm('OperatorMerge');
         $form->setData($data);
 
-
         $formHelper->setFormActionFromRequest($form, $request);
         $form->get('toOperatorId')->setAttribute('data-lookup-url', $this->url()->fromRoute('operator-lookup'));
-
 
         if ($request->isPost() && $form->isValid()) {
             $formData = $form->getData();
@@ -316,7 +313,6 @@ class OperatorController extends AbstractController implements OperatorControlle
         }
 
         $this->scriptFactory->loadFile('operator-merge');
-
 
         $view = new ViewModel(['form' => $form]);
         $view->setTemplate('pages/form');

--- a/module/Olcs/src/Controller/Operator/OperatorController.php
+++ b/module/Olcs/src/Controller/Operator/OperatorController.php
@@ -99,8 +99,8 @@ class OperatorController extends AbstractController implements OperatorControlle
     public function newApplicationAction()
     {
         /**
- * @var \Laminas\Http\Request $request
-*/
+        * @var \Laminas\Http\Request $request
+        */
         $request = $this->getRequest();
 
         if ($request->isPost()) {
@@ -112,8 +112,8 @@ class OperatorController extends AbstractController implements OperatorControlle
         $formHelper = $this->formHelper;
 
         /**
- * @var \Laminas\Form\FormInterface $form
-*/
+        * @var \Laminas\Form\FormInterface $form
+        */
         $form = $formHelper->createForm('NewApplication');
         $form->setData($data);
         $this->alterForm($form, $data);
@@ -159,8 +159,8 @@ class OperatorController extends AbstractController implements OperatorControlle
             $command = $this->transferAnnotationBuilder->createCommand($dto);
 
             /**
- * @var \Common\Service\Cqrs\Response $response
-*/
+            * @var \Common\Service\Cqrs\Response $response
+            */
             $response = $this->commandService->send($command);
 
             if ($response->isOk()) {
@@ -261,13 +261,13 @@ class OperatorController extends AbstractController implements OperatorControlle
      */
     public function mergeAction()
     {
+
         $organisationId = (int) $this->params()->fromRoute('organisation');
 
         $this->licenceDataService->setOrganisationId($organisationId);
-
         /**
- * @var \Laminas\Http\Request $request
-*/
+        * @var \Laminas\Http\Request $request
+        */
         $request = $this->getRequest();
         if ($request->isPost()) {
             $data = (array)$request->getPost();
@@ -280,14 +280,17 @@ class OperatorController extends AbstractController implements OperatorControlle
             $data = ['fromOperatorName' => $organisationData['name']];
         }
 
+
         $formHelper = $this->formHelper;
 
         /* @var $form \Common\Form\Form */
         $form = $formHelper->createForm('OperatorMerge');
         $form->setData($data);
 
+
         $formHelper->setFormActionFromRequest($form, $request);
         $form->get('toOperatorId')->setAttribute('data-lookup-url', $this->url()->fromRoute('operator-lookup'));
+
 
         if ($request->isPost() && $form->isValid()) {
             $formData = $form->getData();
@@ -313,6 +316,7 @@ class OperatorController extends AbstractController implements OperatorControlle
         }
 
         $this->scriptFactory->loadFile('operator-merge');
+
 
         $view = new ViewModel(['form' => $form]);
         $view->setTemplate('pages/form');


### PR DESCRIPTION
## Description

Licence Data Service was being instantiated twice, necessary context not being set on the instance used to populate the form select options.


Related issue: [VOL-4906](https://dvsa.atlassian.net/browse/VOL-4906)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
