### PR TITLE
fix: Non local white screens when using strong types for the container

### DIFF
--- a/module/Olcs/src/Listener/RouteParam/Conversation.php
+++ b/module/Olcs/src/Listener/RouteParam/Conversation.php
@@ -71,7 +71,7 @@ class Conversation implements ListenerAggregateInterface, FactoryInterface
     {
         $this->annotationBuilder = $container->get(AnnotationBuilder::class);
         $this->queryService = $container->get(QueryService::class);
-        $this->navigationPlugin = $container->get(HelperPluginManager::class)->get(Navigation::class);
+        $this->navigationPlugin = $container->get('ViewHelperManager')->get('Navigation');
 
         return $this;
     }


### PR DESCRIPTION
## Description

Locally you can use strong types here to get container items. In dev this resulted in a fatal error and white screen. Unblocker for now until a nicer strongly typed resolution can be added.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
