### PR TITLE
fix: consolidate `Navigation` and `navigation`

### DIFF
--- a/module/Admin/src/Controller/BusNoticePeriodControllerFactory.php
+++ b/module/Admin/src/Controller/BusNoticePeriodControllerFactory.php
@@ -22,7 +22,7 @@ class BusNoticePeriodControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusNoticePeriodController(

--- a/module/Admin/src/Controller/CompaniesHouseAlertControllerFactory.php
+++ b/module/Admin/src/Controller/CompaniesHouseAlertControllerFactory.php
@@ -23,7 +23,7 @@ class CompaniesHouseAlertControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $viewHelperManager = $container->get('ViewHelperManager');

--- a/module/Admin/src/Controller/CpmsReportControllerFactory.php
+++ b/module/Admin/src/Controller/CpmsReportControllerFactory.php
@@ -22,7 +22,7 @@ class CpmsReportControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new CpmsReportController(

--- a/module/Admin/src/Controller/DataRetention/ExportControllerFactory.php
+++ b/module/Admin/src/Controller/DataRetention/ExportControllerFactory.php
@@ -24,7 +24,7 @@ class ExportControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Admin/src/Controller/DataRetentionControllerFactory.php
+++ b/module/Admin/src/Controller/DataRetentionControllerFactory.php
@@ -22,7 +22,7 @@ class DataRetentionControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new DataRetentionController(

--- a/module/Admin/src/Controller/DataRetentionReviewControllerFactory.php
+++ b/module/Admin/src/Controller/DataRetentionReviewControllerFactory.php
@@ -22,7 +22,7 @@ class DataRetentionReviewControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new DataRetentionReviewController(

--- a/module/Admin/src/Controller/DocumentTemplateControllerFactory.php
+++ b/module/Admin/src/Controller/DocumentTemplateControllerFactory.php
@@ -25,7 +25,7 @@ class DocumentTemplateControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $scannerAntiVirusService = $container->get(Scan::class);

--- a/module/Admin/src/Controller/EditableTranslationsControllerFactory.php
+++ b/module/Admin/src/Controller/EditableTranslationsControllerFactory.php
@@ -22,7 +22,7 @@ class EditableTranslationsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new EditableTranslationsController(

--- a/module/Admin/src/Controller/FeatureToggleControllerFactory.php
+++ b/module/Admin/src/Controller/FeatureToggleControllerFactory.php
@@ -22,7 +22,7 @@ class FeatureToggleControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new FeatureToggleController(

--- a/module/Admin/src/Controller/FeeRateControllerFactory.php
+++ b/module/Admin/src/Controller/FeeRateControllerFactory.php
@@ -22,7 +22,7 @@ class FeeRateControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new FeeRateController(

--- a/module/Admin/src/Controller/FinancialStandingRateControllerFactory.php
+++ b/module/Admin/src/Controller/FinancialStandingRateControllerFactory.php
@@ -22,7 +22,7 @@ class FinancialStandingRateControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new FinancialStandingRateController(

--- a/module/Admin/src/Controller/InterimRefundsControllerFactory.php
+++ b/module/Admin/src/Controller/InterimRefundsControllerFactory.php
@@ -23,7 +23,7 @@ class InterimRefundsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $dateHelper = $container->get(DateHelperService::class);

--- a/module/Admin/src/Controller/IrfoPsvAuthContinuationControllerFactory.php
+++ b/module/Admin/src/Controller/IrfoPsvAuthContinuationControllerFactory.php
@@ -22,7 +22,7 @@ class IrfoPsvAuthContinuationControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrfoPsvAuthContinuationController(

--- a/module/Admin/src/Controller/IrfoStockControlControllerFactory.php
+++ b/module/Admin/src/Controller/IrfoStockControlControllerFactory.php
@@ -25,7 +25,7 @@ class IrfoStockControlControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $dateHelperService = $container->get(DateHelperService::class);

--- a/module/Admin/src/Controller/IrhpPermitJurisdictionControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitJurisdictionControllerFactory.php
@@ -23,7 +23,7 @@ class IrhpPermitJurisdictionControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $scriptFactory = $container->get(ScriptFactory::class);

--- a/module/Admin/src/Controller/IrhpPermitPrintControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitPrintControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpPermitPrintControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpPermitPrintController(

--- a/module/Admin/src/Controller/IrhpPermitRangeControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitRangeControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpPermitRangeControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpPermitRangeController(

--- a/module/Admin/src/Controller/IrhpPermitReportingControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitReportingControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpPermitReportingControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpPermitReportingController(

--- a/module/Admin/src/Controller/IrhpPermitScoringControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitScoringControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpPermitScoringControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpPermitScoringController(

--- a/module/Admin/src/Controller/IrhpPermitSectorControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitSectorControllerFactory.php
@@ -23,7 +23,7 @@ class IrhpPermitSectorControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $scriptFactory = $container->get(ScriptFactory::class);

--- a/module/Admin/src/Controller/IrhpPermitStockControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitStockControllerFactory.php
@@ -23,7 +23,7 @@ class IrhpPermitStockControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $scriptFactory = $container->get(ScriptFactory::class);

--- a/module/Admin/src/Controller/IrhpPermitWindowControllerFactory.php
+++ b/module/Admin/src/Controller/IrhpPermitWindowControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpPermitWindowControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpPermitWindowController(

--- a/module/Admin/src/Controller/MyDetailsControllerFactory.php
+++ b/module/Admin/src/Controller/MyDetailsControllerFactory.php
@@ -22,7 +22,7 @@ class MyDetailsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new MyDetailsController(

--- a/module/Admin/src/Controller/PartnerControllerFactory.php
+++ b/module/Admin/src/Controller/PartnerControllerFactory.php
@@ -22,7 +22,7 @@ class PartnerControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PartnerController(

--- a/module/Admin/src/Controller/PermitsControllerFactory.php
+++ b/module/Admin/src/Controller/PermitsControllerFactory.php
@@ -22,7 +22,7 @@ class PermitsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PermitsController(

--- a/module/Admin/src/Controller/PermitsReportControllerFactory.php
+++ b/module/Admin/src/Controller/PermitsReportControllerFactory.php
@@ -22,7 +22,7 @@ class PermitsReportControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PermitsReportController(

--- a/module/Admin/src/Controller/PiReportControllerFactory.php
+++ b/module/Admin/src/Controller/PiReportControllerFactory.php
@@ -23,7 +23,7 @@ class PiReportControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $dateHelperService = $container->get(DateHelperService::class);

--- a/module/Admin/src/Controller/PresidingTcControllerFactory.php
+++ b/module/Admin/src/Controller/PresidingTcControllerFactory.php
@@ -22,7 +22,7 @@ class PresidingTcControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PresidingTcController(

--- a/module/Admin/src/Controller/PrintingControllerFactory.php
+++ b/module/Admin/src/Controller/PrintingControllerFactory.php
@@ -22,7 +22,7 @@ class PrintingControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PrintingController(

--- a/module/Admin/src/Controller/PublicHolidayControllerFactory.php
+++ b/module/Admin/src/Controller/PublicHolidayControllerFactory.php
@@ -22,7 +22,7 @@ class PublicHolidayControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PublicHolidayController(

--- a/module/Admin/src/Controller/PublicationControllerFactory.php
+++ b/module/Admin/src/Controller/PublicationControllerFactory.php
@@ -23,7 +23,7 @@ class PublicationControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $webDavJsonWebTokenGenerationService = $container->get(WebDavJsonWebTokenGenerationService::class);

--- a/module/Admin/src/Controller/PublishedPublicationControllerFactory.php
+++ b/module/Admin/src/Controller/PublishedPublicationControllerFactory.php
@@ -22,7 +22,7 @@ class PublishedPublicationControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PublishedPublicationController(

--- a/module/Admin/src/Controller/RecipientControllerFactory.php
+++ b/module/Admin/src/Controller/RecipientControllerFactory.php
@@ -22,7 +22,7 @@ class RecipientControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new RecipientController(

--- a/module/Admin/src/Controller/ReplacementsControllerFactory.php
+++ b/module/Admin/src/Controller/ReplacementsControllerFactory.php
@@ -22,7 +22,7 @@ class ReplacementsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReplacementsController(

--- a/module/Admin/src/Controller/ReportCasesOpenControllerFactory.php
+++ b/module/Admin/src/Controller/ReportCasesOpenControllerFactory.php
@@ -22,7 +22,7 @@ class ReportCasesOpenControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReportCasesOpenController(

--- a/module/Admin/src/Controller/ReportUploadControllerFactory.php
+++ b/module/Admin/src/Controller/ReportUploadControllerFactory.php
@@ -23,7 +23,7 @@ class ReportUploadControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $scannerAntiVirusService = $container->get(Scan::class);

--- a/module/Admin/src/Controller/SystemInfoMessageControllerFactory.php
+++ b/module/Admin/src/Controller/SystemInfoMessageControllerFactory.php
@@ -22,7 +22,7 @@ class SystemInfoMessageControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new SystemInfoMessageController(

--- a/module/Admin/src/Controller/SystemParametersControllerFactory.php
+++ b/module/Admin/src/Controller/SystemParametersControllerFactory.php
@@ -22,7 +22,7 @@ class SystemParametersControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new SystemParametersController(

--- a/module/Admin/src/Controller/TaskAllocationRulesControllerFactory.php
+++ b/module/Admin/src/Controller/TaskAllocationRulesControllerFactory.php
@@ -24,7 +24,7 @@ class TaskAllocationRulesControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Admin/src/Controller/TeamControllerFactory.php
+++ b/module/Admin/src/Controller/TeamControllerFactory.php
@@ -26,7 +26,7 @@ class TeamControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $viewHelperManager = $container->get('ViewHelperManager');

--- a/module/Admin/src/Controller/TemplateControllerFactory.php
+++ b/module/Admin/src/Controller/TemplateControllerFactory.php
@@ -22,7 +22,7 @@ class TemplateControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new TemplateController(

--- a/module/Admin/src/Controller/UserManagementControllerFactory.php
+++ b/module/Admin/src/Controller/UserManagementControllerFactory.php
@@ -23,7 +23,7 @@ class UserManagementControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $urlHelper = $container->get(UrlHelperService::class);

--- a/module/Admin/src/Listener/RouteParam/IrhpPermitAdminFurniture.php
+++ b/module/Admin/src/Listener/RouteParam/IrhpPermitAdminFurniture.php
@@ -47,7 +47,7 @@ class IrhpPermitAdminFurniture implements
         $this->setQuerySender($container->get('QuerySender'));
         $this->setCommandSender($container->get('CommandSender'));
         $this->setViewHelperManager($container->get('ViewHelperManager'));
-        $this->setNavigationService($container->get('Navigation'));
+        $this->setNavigationService($container->get('navigation'));
 
         return $this;
     }

--- a/module/Olcs/config/module.config.php
+++ b/module/Olcs/config/module.config.php
@@ -737,8 +737,6 @@ return array(
 
             Auth\Adapter\InternalCommandAdapter::class => Auth\Adapter\InternalCommandAdapterFactory::class,
             'RoutePluginManager' => Laminas\Router\RoutePluginManagerFactory::class,
-            'navigation' => 'Laminas\Navigation\Service\DefaultNavigationFactory',
-            'Navigation' => 'Laminas\Navigation\Service\DefaultNavigationFactory',
             \Olcs\Listener\RouteParams::class => \Olcs\Listener\RouteParamsFactory::class,
         )
     ),

--- a/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingInspectionRequestControllerFactory.php
+++ b/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingInspectionRequestControllerFactory.php
@@ -25,7 +25,7 @@ class ApplicationProcessingInspectionRequestControllerFactory implements Factory
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelper instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $transferAnnotationBuilder = $container->get(TransferAnnotationBuilder::class);

--- a/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingNoteControllerFactory.php
+++ b/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingNoteControllerFactory.php
@@ -22,7 +22,7 @@ class ApplicationProcessingNoteControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ApplicationProcessingNoteController(

--- a/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingPublicationsControllerFactory.php
+++ b/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingPublicationsControllerFactory.php
@@ -22,7 +22,7 @@ class ApplicationProcessingPublicationsControllerFactory implements FactoryInter
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ApplicationProcessingPublicationsController(

--- a/module/Olcs/src/Controller/Application/Processing/HistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Application/Processing/HistoryControllerFactory.php
@@ -23,7 +23,7 @@ class HistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableBuilder = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/Application/Processing/ReadHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Application/Processing/ReadHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class ReadHistoryControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReadHistoryController(

--- a/module/Olcs/src/Controller/Bus/BusRequestMapControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/BusRequestMapControllerFactory.php
@@ -22,7 +22,7 @@ class BusRequestMapControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusRequestMapController(

--- a/module/Olcs/src/Controller/Bus/Details/BusDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Details/BusDetailsControllerFactory.php
@@ -22,7 +22,7 @@ class BusDetailsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusDetailsController(

--- a/module/Olcs/src/Controller/Bus/Processing/BusProcessingDecisionControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Processing/BusProcessingDecisionControllerFactory.php
@@ -22,7 +22,7 @@ class BusProcessingDecisionControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusProcessingDecisionController(

--- a/module/Olcs/src/Controller/Bus/Processing/BusProcessingNoteControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Processing/BusProcessingNoteControllerFactory.php
@@ -22,7 +22,7 @@ class BusProcessingNoteControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusProcessingNoteController(

--- a/module/Olcs/src/Controller/Bus/Processing/BusProcessingRegistrationHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Processing/BusProcessingRegistrationHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class BusProcessingRegistrationHistoryControllerFactory implements FactoryInterf
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusProcessingRegistrationHistoryController(

--- a/module/Olcs/src/Controller/Bus/Processing/HistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Processing/HistoryControllerFactory.php
@@ -23,7 +23,7 @@ class HistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/Bus/Processing/ReadHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Processing/ReadHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class ReadHistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReadHistoryController(

--- a/module/Olcs/src/Controller/Bus/Service/BusServiceControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Service/BusServiceControllerFactory.php
@@ -26,7 +26,7 @@ class BusServiceControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusServiceController(

--- a/module/Olcs/src/Controller/Bus/Short/BusShortControllerFactory.php
+++ b/module/Olcs/src/Controller/Bus/Short/BusShortControllerFactory.php
@@ -22,7 +22,7 @@ class BusShortControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusShortController(

--- a/module/Olcs/src/Controller/Cases/AnnualTestHistory/AnnualTestHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/AnnualTestHistory/AnnualTestHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class AnnualTestHistoryControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new AnnualTestHistoryController(

--- a/module/Olcs/src/Controller/Cases/Complaint/ComplaintControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Complaint/ComplaintControllerFactory.php
@@ -22,7 +22,7 @@ class ComplaintControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ComplaintController(

--- a/module/Olcs/src/Controller/Cases/Complaint/EnvironmentalComplaintControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Complaint/EnvironmentalComplaintControllerFactory.php
@@ -22,7 +22,7 @@ class EnvironmentalComplaintControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new EnvironmentalComplaintController(

--- a/module/Olcs/src/Controller/Cases/ConditionUndertaking/ConditionUndertakingControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/ConditionUndertaking/ConditionUndertakingControllerFactory.php
@@ -23,7 +23,7 @@ class ConditionUndertakingControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $viewHelperManager = $container->get('ViewHelperManager');

--- a/module/Olcs/src/Controller/Cases/Conviction/ConvictionControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Conviction/ConvictionControllerFactory.php
@@ -22,7 +22,7 @@ class ConvictionControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ConvictionController(

--- a/module/Olcs/src/Controller/Cases/Conviction/LegacyOffenceControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Conviction/LegacyOffenceControllerFactory.php
@@ -22,7 +22,7 @@ class LegacyOffenceControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new LegacyOffenceController(

--- a/module/Olcs/src/Controller/Cases/Hearing/AppealControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Hearing/AppealControllerFactory.php
@@ -22,7 +22,7 @@ class AppealControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new AppealController(

--- a/module/Olcs/src/Controller/Cases/Hearing/HearingAppealControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Hearing/HearingAppealControllerFactory.php
@@ -22,7 +22,7 @@ class HearingAppealControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new HearingAppealController(

--- a/module/Olcs/src/Controller/Cases/Hearing/StayControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Hearing/StayControllerFactory.php
@@ -22,7 +22,7 @@ class StayControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new StayController(

--- a/module/Olcs/src/Controller/Cases/Impounding/ImpoundingControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Impounding/ImpoundingControllerFactory.php
@@ -22,7 +22,7 @@ class ImpoundingControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ImpoundingController(

--- a/module/Olcs/src/Controller/Cases/NonPublicInquiry/NonPublicInquiryControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/NonPublicInquiry/NonPublicInquiryControllerFactory.php
@@ -22,7 +22,7 @@ class NonPublicInquiryControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new NonPublicInquiryController(

--- a/module/Olcs/src/Controller/Cases/Opposition/OppositionControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Opposition/OppositionControllerFactory.php
@@ -22,7 +22,7 @@ class OppositionControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelper instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OppositionController(

--- a/module/Olcs/src/Controller/Cases/Overview/OverviewControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Overview/OverviewControllerFactory.php
@@ -22,7 +22,7 @@ class OverviewControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OverviewController(

--- a/module/Olcs/src/Controller/Cases/Penalty/PenaltyControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Penalty/PenaltyControllerFactory.php
@@ -23,7 +23,7 @@ class PenaltyControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/Cases/Penalty/SiControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Penalty/SiControllerFactory.php
@@ -22,7 +22,7 @@ class SiControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new SiController(

--- a/module/Olcs/src/Controller/Cases/Processing/DecisionsControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/DecisionsControllerFactory.php
@@ -22,7 +22,7 @@ class DecisionsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new DecisionsController(

--- a/module/Olcs/src/Controller/Cases/Processing/DecisionsDeclareUnfitControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/DecisionsDeclareUnfitControllerFactory.php
@@ -22,7 +22,7 @@ class DecisionsDeclareUnfitControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new DecisionsDeclareUnfitController(

--- a/module/Olcs/src/Controller/Cases/Processing/DecisionsNoFurtherActionControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/DecisionsNoFurtherActionControllerFactory.php
@@ -22,7 +22,7 @@ class DecisionsNoFurtherActionControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new DecisionsNoFurtherActionController(

--- a/module/Olcs/src/Controller/Cases/Processing/DecisionsReputeNotLostControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/DecisionsReputeNotLostControllerFactory.php
@@ -22,7 +22,7 @@ class DecisionsReputeNotLostControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new DecisionsReputeNotLostController(

--- a/module/Olcs/src/Controller/Cases/Processing/HistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/HistoryControllerFactory.php
@@ -23,7 +23,7 @@ class HistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableBuilder = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/Cases/Processing/NoteControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/NoteControllerFactory.php
@@ -22,7 +22,7 @@ class NoteControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new NoteController(

--- a/module/Olcs/src/Controller/Cases/Processing/ReadHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/ReadHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class ReadHistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReadHistoryController(

--- a/module/Olcs/src/Controller/Cases/Processing/RevokeControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Processing/RevokeControllerFactory.php
@@ -22,7 +22,7 @@ class RevokeControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new RevokeController(

--- a/module/Olcs/src/Controller/Cases/Prohibition/ProhibitionControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Prohibition/ProhibitionControllerFactory.php
@@ -22,7 +22,7 @@ class ProhibitionControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ProhibitionController(

--- a/module/Olcs/src/Controller/Cases/Prohibition/ProhibitionDefectControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Prohibition/ProhibitionDefectControllerFactory.php
@@ -22,7 +22,7 @@ class ProhibitionDefectControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ProhibitionDefectController(

--- a/module/Olcs/src/Controller/Cases/PublicInquiry/HearingControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/PublicInquiry/HearingControllerFactory.php
@@ -22,7 +22,7 @@ class HearingControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new HearingController(

--- a/module/Olcs/src/Controller/Cases/PublicInquiry/PiControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/PublicInquiry/PiControllerFactory.php
@@ -23,7 +23,7 @@ class PiControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $scriptService = $container->get(ScriptFactory::class);

--- a/module/Olcs/src/Controller/Cases/Statement/StatementControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Statement/StatementControllerFactory.php
@@ -22,7 +22,7 @@ class StatementControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new StatementController(

--- a/module/Olcs/src/Controller/Cases/Submission/DecisionControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Submission/DecisionControllerFactory.php
@@ -22,7 +22,7 @@ class DecisionControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new DecisionController(

--- a/module/Olcs/src/Controller/Cases/Submission/ProcessSubmissionControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Submission/ProcessSubmissionControllerFactory.php
@@ -22,7 +22,7 @@ class ProcessSubmissionControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ProcessSubmissionController(

--- a/module/Olcs/src/Controller/Cases/Submission/RecommendationControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Submission/RecommendationControllerFactory.php
@@ -22,7 +22,7 @@ class RecommendationControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new RecommendationController(

--- a/module/Olcs/src/Controller/Cases/Submission/SubmissionControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Submission/SubmissionControllerFactory.php
@@ -27,7 +27,7 @@ class SubmissionControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $urlHelper = $container->get(UrlHelperService::class);

--- a/module/Olcs/src/Controller/Cases/Submission/SubmissionSectionCommentControllerFactory.php
+++ b/module/Olcs/src/Controller/Cases/Submission/SubmissionSectionCommentControllerFactory.php
@@ -22,7 +22,7 @@ class SubmissionSectionCommentControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new SubmissionSectionCommentController(

--- a/module/Olcs/src/Controller/Factory/Application/ApplicationControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Application/ApplicationControllerFactory.php
@@ -32,7 +32,7 @@ class ApplicationControllerFactory implements FactoryInterface
         $oppositionHelper = $container->get(OppositionHelperService::class);
         $complaintsHelper = $container->get(ComplaintsHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ApplicationController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Application/ApplicationSchedule41ControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Application/ApplicationSchedule41ControllerFactory.php
@@ -29,7 +29,7 @@ class ApplicationSchedule41ControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $restrictionHelper = $container->get(RestrictionHelperService::class);
 
         return new ApplicationSchedule41Controller(

--- a/module/Olcs/src/Controller/Factory/Application/Docs/ApplicationDocsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Application/Docs/ApplicationDocsControllerFactory.php
@@ -36,7 +36,7 @@ class ApplicationDocsControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $docSubCategoryDataService = $container->get(PluginManager::class)->get(DocumentSubCategory::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ApplicationDocsController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Application/Fees/ApplicationFeesControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Application/Fees/ApplicationFeesControllerFactory.php
@@ -40,7 +40,7 @@ class ApplicationFeesControllerFactory implements FactoryInterface
         $identityProvider = $container->get(IdentityProviderInterface::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $dateHelper = $container->get(DateHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ApplicationFeesController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Application/Processing/ApplicationProcessingOverviewControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Application/Processing/ApplicationProcessingOverviewControllerFactory.php
@@ -33,7 +33,7 @@ class ApplicationProcessingOverviewControllerFactory implements FactoryInterface
         $complaintsHelper = $container->get(ComplaintsHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $router = $container->get('router');
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ApplicationProcessingOverviewController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Application/Processing/ApplicationProcessingTasksControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Application/Processing/ApplicationProcessingTasksControllerFactory.php
@@ -35,7 +35,7 @@ class ApplicationProcessingTasksControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $router = $container->get('router');
         $subCategoryDataService = $container->get(PluginManager::class)->get(SubCategory::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ApplicationProcessingTasksController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Licence/Docs/LicenceDocsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Licence/Docs/LicenceDocsControllerFactory.php
@@ -34,7 +34,7 @@ class LicenceDocsControllerFactory implements FactoryInterface
         $oppositionHelper = $container->get(OppositionHelperService::class);
         $complaintsHelper = $container->get(ComplaintsHelperService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
 
         return new LicenceDocsController(

--- a/module/Olcs/src/Controller/Factory/Licence/Fees/LicenceFeesControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Licence/Fees/LicenceFeesControllerFactory.php
@@ -38,7 +38,7 @@ class LicenceFeesControllerFactory implements FactoryInterface
         $identityProvider = $container->get(IdentityProviderInterface::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $dateHelper = $container->get(DateHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new LicenceFeesController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Licence/LicenceControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Licence/LicenceControllerFactory.php
@@ -30,7 +30,7 @@ class LicenceControllerFactory implements FactoryInterface
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $oppositionHelper = $container->get(OppositionHelperService::class);
         $complaintsHelper = $container->get(ComplaintsHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
 
         return new LicenceController(

--- a/module/Olcs/src/Controller/Factory/Licence/LicenceDecisionsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Licence/LicenceDecisionsControllerFactory.php
@@ -26,7 +26,7 @@ class LicenceDecisionsControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new LicenceDecisionsController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Licence/LicenceGracePeriodsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Licence/LicenceGracePeriodsControllerFactory.php
@@ -28,7 +28,7 @@ class LicenceGracePeriodsControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $formHelper = $container->get(FormHelperService::class);
         $scriptFactory = $container->get(ScriptFactory::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new LicenceGracePeriodsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Factory/Licence/Processing/LicenceProcessingOverviewControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Licence/Processing/LicenceProcessingOverviewControllerFactory.php
@@ -32,7 +32,7 @@ class LicenceProcessingOverviewControllerFactory implements FactoryInterface
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $oppositionHelper = $container->get(OppositionHelperService::class);
         $complaintsHelper = $container->get(ComplaintsHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $subCategoryDataService = $container->get(PluginManager::class)->get(SubCategory::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $router = $container->get(TreeRouteStack::class);

--- a/module/Olcs/src/Controller/Factory/Licence/Processing/LicenceProcessingTasksControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Licence/Processing/LicenceProcessingTasksControllerFactory.php
@@ -32,7 +32,7 @@ class LicenceProcessingTasksControllerFactory implements FactoryInterface
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $oppositionHelper = $container->get(OppositionHelperService::class);
         $complaintsHelper = $container->get(ComplaintsHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $subCategoryDataService = $container->get(PluginManager::class)->get(SubCategory::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $router = $container->get(TreeRouteStack::class);

--- a/module/Olcs/src/Controller/Factory/Operator/Cases/UnlicensedCasesOperatorControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/Cases/UnlicensedCasesOperatorControllerFactory.php
@@ -37,7 +37,7 @@ class UnlicensedCasesOperatorControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new UnlicensedCasesOperatorController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Operator/Docs/OperatorDocsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/Docs/OperatorDocsControllerFactory.php
@@ -39,7 +39,7 @@ class OperatorDocsControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $docSubCategoryDataService = $container->get(PluginManager::class)->get(DocumentSubCategory::class);
         $translationHelper = $container->get(TranslationHelperService::class);
 

--- a/module/Olcs/src/Controller/Factory/Operator/HistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/HistoryControllerFactory.php
@@ -38,7 +38,7 @@ class HistoryControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new HistoryController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorBusinessDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorBusinessDetailsControllerFactory.php
@@ -40,7 +40,7 @@ class OperatorBusinessDetailsControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $translationHelper = $container->get(TranslationHelperService::class);
 
         return new OperatorBusinessDetailsController(

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorControllerFactory.php
@@ -37,7 +37,7 @@ class OperatorControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new OperatorController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorFeesControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorFeesControllerFactory.php
@@ -41,7 +41,7 @@ class OperatorFeesControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $translationHelper = $container->get(TranslationHelperService::class);
         $urlHelper = $container->get(UrlHelperService::class);
         $identityProvider = $container->get(IdentityProviderInterface::class);

--- a/module/Olcs/src/Controller/Factory/Operator/OperatorProcessingTasksControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/OperatorProcessingTasksControllerFactory.php
@@ -38,7 +38,7 @@ class OperatorProcessingTasksControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $subCategoryDataService = $container->get(PluginManager::class)->get(SubCategory::class);
 
         return new OperatorProcessingTasksController(

--- a/module/Olcs/src/Controller/Factory/Operator/UnlicensedBusinessDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Operator/UnlicensedBusinessDetailsControllerFactory.php
@@ -39,7 +39,7 @@ class UnlicensedBusinessDetailsControllerFactory implements FactoryInterface
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $licenceDataService = $container->get(PluginManager::class)->get(Licence::class);
         $queryService = $container->get(QueryService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $translationHelper = $container->get(TranslationHelperService::class);
 
         return new UnlicensedBusinessDetailsController(

--- a/module/Olcs/src/Controller/Factory/SearchControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/SearchControllerFactory.php
@@ -27,7 +27,7 @@ class SearchControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $roleService = $container->get(RoleService::class);
         $placeHolder = $container->get('ViewHelperManager')->get('placeholder');
 

--- a/module/Olcs/src/Controller/Factory/TransportManager/Details/TransportManagerDetailsPreviousHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/TransportManager/Details/TransportManagerDetailsPreviousHistoryControllerFactory.php
@@ -30,7 +30,7 @@ class TransportManagerDetailsPreviousHistoryControllerFactory implements Factory
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $transportManagerHelper = $container->get(TransportManagerHelperService::class);
         $uploadHelper = $container->get(FileUploadHelperService::class);
 

--- a/module/Olcs/src/Controller/Factory/TransportManager/Details/TransportManagerDetailsResponsibilityControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/TransportManager/Details/TransportManagerDetailsResponsibilityControllerFactory.php
@@ -34,7 +34,7 @@ class TransportManagerDetailsResponsibilityControllerFactory implements FactoryI
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $transportManagerHelper = $container->get(TransportManagerHelperService::class);
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $commandService = $container->get(CommandService::class);

--- a/module/Olcs/src/Controller/Factory/TransportManager/Processing/TransportManagerProcessingTaskControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/TransportManager/Processing/TransportManagerProcessingTaskControllerFactory.php
@@ -30,7 +30,7 @@ class TransportManagerProcessingTaskControllerFactory implements FactoryInterfac
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $subCategoryDataService = $container->get(PluginManager::class)->get(SubCategory::class);
 
         return new TransportManagerProcessingTaskController(

--- a/module/Olcs/src/Controller/Factory/TransportManager/TransportManagerControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/TransportManager/TransportManagerControllerFactory.php
@@ -28,7 +28,7 @@ class TransportManagerControllerFactory implements FactoryInterface
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TransportManagerController(
             $scriptFactory,

--- a/module/Olcs/src/Controller/Factory/TransportManager/TransportManagerDocumentControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/TransportManager/TransportManagerDocumentControllerFactory.php
@@ -31,7 +31,7 @@ class TransportManagerDocumentControllerFactory implements FactoryInterface
         $viewHelperManager = $container->get(HelperPluginManager::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $docSubCategoryDataService = $container->get(PluginManager::class)->get(DocumentSubCategory::class);
 
         return new TransportManagerDocumentController(

--- a/module/Olcs/src/Controller/Factory/Variation/VariationSchedule41ControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Variation/VariationSchedule41ControllerFactory.php
@@ -28,7 +28,7 @@ class VariationSchedule41ControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VariationSchedule41Controller(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/IrhpPermits/ApplicationControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/ApplicationControllerFactory.php
@@ -22,7 +22,7 @@ class ApplicationControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ApplicationController(

--- a/module/Olcs/src/Controller/IrhpPermits/ChangeHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/ChangeHistoryControllerFactory.php
@@ -23,7 +23,7 @@ class ChangeHistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationControllerFactory.php
@@ -26,7 +26,7 @@ class IrhpApplicationControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $QaFieldsetPopulator = $container->get('QaFieldsetPopulator');

--- a/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationProcessingHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationProcessingHistoryControllerFactory.php
@@ -23,7 +23,7 @@ class IrhpApplicationProcessingHistoryControllerFactory implements FactoryInterf
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationProcessingNoteControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationProcessingNoteControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpApplicationProcessingNoteControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpApplicationProcessingNoteController(

--- a/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationProcessingReadHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/IrhpApplicationProcessingReadHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpApplicationProcessingReadHistoryControllerFactory implements FactoryIn
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpApplicationProcessingReadHistoryController(

--- a/module/Olcs/src/Controller/IrhpPermits/IrhpPermitControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/IrhpPermitControllerFactory.php
@@ -22,7 +22,7 @@ class IrhpPermitControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new IrhpPermitController(

--- a/module/Olcs/src/Controller/IrhpPermits/PermitControllerFactory.php
+++ b/module/Olcs/src/Controller/IrhpPermits/PermitControllerFactory.php
@@ -22,7 +22,7 @@ class PermitControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PermitController(

--- a/module/Olcs/src/Controller/Licence/BusRegistrationControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/BusRegistrationControllerFactory.php
@@ -22,7 +22,7 @@ class BusRegistrationControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new BusRegistrationController(

--- a/module/Olcs/src/Controller/Licence/Processing/HistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/Processing/HistoryControllerFactory.php
@@ -23,7 +23,7 @@ class HistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingInspectionRequestControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingInspectionRequestControllerFactory.php
@@ -25,7 +25,7 @@ class LicenceProcessingInspectionRequestControllerFactory implements FactoryInte
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $setUpOcListboxService = $container->get(OperatingCentresForInspectionRequest::class);

--- a/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingNoteControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingNoteControllerFactory.php
@@ -25,7 +25,7 @@ class LicenceProcessingNoteControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new LicenceProcessingNoteController(

--- a/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingPublicationsControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingPublicationsControllerFactory.php
@@ -22,7 +22,7 @@ class LicenceProcessingPublicationsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new LicenceProcessingPublicationsController(

--- a/module/Olcs/src/Controller/Licence/Processing/ReadHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/Processing/ReadHistoryControllerFactory.php
@@ -23,7 +23,7 @@ class ReadHistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReadHistoryController(

--- a/module/Olcs/src/Controller/Licence/SurrenderControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/SurrenderControllerFactory.php
@@ -22,7 +22,7 @@ class SurrenderControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new SurrenderController(

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/AddressesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/AddressesControllerFactory.php
@@ -24,7 +24,7 @@ class AddressesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): AddressesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -33,7 +33,7 @@ class AddressesControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new AddressesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/BusinessDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/BusinessDetailsControllerFactory.php
@@ -27,7 +27,7 @@ class BusinessDetailsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): BusinessDetailsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -39,7 +39,7 @@ class BusinessDetailsControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $fileUploadHelper = $container->get(FileUploadHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new BusinessDetailsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/BusinessTypeControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/BusinessTypeControllerFactory.php
@@ -29,7 +29,7 @@ class BusinessTypeControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): BusinessTypeController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -43,7 +43,7 @@ class BusinessTypeControllerFactory implements FactoryInterface
         $translationHelper = $container->get(TranslationHelperService::class);
         $lvaAdapter = $container->get(GenericBusinessTypeAdapter::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new BusinessTypeController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/CommunityLicencesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/CommunityLicencesControllerFactory.php
@@ -37,7 +37,7 @@ class CommunityLicencesControllerFactory implements FactoryInterface
         $commandService = $container->get(CommandService::class);
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new CommunityLicencesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/ConditionsUndertakingsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/ConditionsUndertakingsControllerFactory.php
@@ -25,7 +25,7 @@ class ConditionsUndertakingsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ConditionsUndertakingsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class ConditionsUndertakingsControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $lvaAdapter = $container->get(ApplicationConditionsUndertakingsAdapter::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ConditionsUndertakingsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/ConvictionsPenaltiesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/ConvictionsPenaltiesControllerFactory.php
@@ -25,7 +25,7 @@ class ConvictionsPenaltiesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ConvictionsPenaltiesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class ConvictionsPenaltiesControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
         $scriptFactory = $container->get(ScriptFactory::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ConvictionsPenaltiesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/DeclarationsInternalControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/DeclarationsInternalControllerFactory.php
@@ -23,7 +23,7 @@ class DeclarationsInternalControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): DeclarationsInternalController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class DeclarationsInternalControllerFactory implements FactoryInterface
         $formServiceManager = $container->get(FormServiceManager::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new DeclarationsInternalController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/FinancialEvidenceControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/FinancialEvidenceControllerFactory.php
@@ -28,7 +28,7 @@ class FinancialEvidenceControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): FinancialEvidenceController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $tableFactory = $container->get(TableFactory::class);
@@ -41,7 +41,7 @@ class FinancialEvidenceControllerFactory implements FactoryInterface
         $lvaAdapter = $container->get(ApplicationFinancialEvidenceAdapter::class);
         $uploadHelper = $container->get(FileUploadHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new FinancialEvidenceController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/FinancialHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/FinancialHistoryControllerFactory.php
@@ -25,7 +25,7 @@ class FinancialHistoryControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): FinancialHistoryController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -35,7 +35,7 @@ class FinancialHistoryControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $uploadHelper = $container->get(FileUploadHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new FinancialHistoryController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/GrantControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/GrantControllerFactory.php
@@ -24,7 +24,7 @@ class GrantControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): GrantController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -33,7 +33,7 @@ class GrantControllerFactory implements FactoryInterface
         $translationHelper = $container->get(TranslationHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new GrantController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/InterimControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/InterimControllerFactory.php
@@ -33,7 +33,7 @@ class InterimControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new InterimController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/LicenceHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/LicenceHistoryControllerFactory.php
@@ -25,7 +25,7 @@ class LicenceHistoryControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LicenceHistoryController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -35,7 +35,7 @@ class LicenceHistoryControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $formHelper = $container->get(FormHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new LicenceHistoryController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/NotTakenUpControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/NotTakenUpControllerFactory.php
@@ -23,7 +23,7 @@ class NotTakenUpControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): NotTakenUpController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class NotTakenUpControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new NotTakenUpController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/OperatingCentresControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/OperatingCentresControllerFactory.php
@@ -27,7 +27,7 @@ class OperatingCentresControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): OperatingCentresController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -39,7 +39,7 @@ class OperatingCentresControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
         $uploadHelper = $container->get(FileUploadHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new OperatingCentresController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/OverviewControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/OverviewControllerFactory.php
@@ -23,7 +23,7 @@ class OverviewControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): OverviewController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $stringHelper = $container->get(StringHelperService::class);
@@ -31,7 +31,7 @@ class OverviewControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new OverviewController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/PeopleControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/PeopleControllerFactory.php
@@ -39,7 +39,7 @@ class PeopleControllerFactory implements FactoryInterface
         $lvaAdapter = $container->get(ApplicationPeopleAdapter::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new PeopleController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/PublishControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/PublishControllerFactory.php
@@ -22,14 +22,14 @@ class PublishControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): PublishController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new PublishController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/RefuseControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/RefuseControllerFactory.php
@@ -23,7 +23,7 @@ class RefuseControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): RefuseController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class RefuseControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new RefuseController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/ReviveApplicationControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/ReviveApplicationControllerFactory.php
@@ -23,7 +23,7 @@ class ReviveApplicationControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ReviveApplicationController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class ReviveApplicationControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ReviveApplicationController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/SafetyControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/SafetyControllerFactory.php
@@ -26,7 +26,7 @@ class SafetyControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): SafetyController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -37,7 +37,7 @@ class SafetyControllerFactory implements FactoryInterface
         $translationHelper = $container->get(TranslationHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new SafetyController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/SubmitControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/SubmitControllerFactory.php
@@ -23,7 +23,7 @@ class SubmitControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): SubmitController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class SubmitControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new SubmitController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/TaxiPhvControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/TaxiPhvControllerFactory.php
@@ -26,7 +26,7 @@ class TaxiPhvControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TaxiPhvController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -37,7 +37,7 @@ class TaxiPhvControllerFactory implements FactoryInterface
         $translationHelper = $container->get(TranslationHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TaxiPhvController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/TransportManagersControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/TransportManagersControllerFactory.php
@@ -29,7 +29,7 @@ class TransportManagersControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TransportManagersController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -43,7 +43,7 @@ class TransportManagersControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $lvaAdapter = $container->get(ApplicationTransportManagerAdapter::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TransportManagersController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/TypeOfLicenceControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/TypeOfLicenceControllerFactory.php
@@ -24,7 +24,7 @@ class TypeOfLicenceControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TypeOfLicenceController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -33,7 +33,7 @@ class TypeOfLicenceControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
         $formHelper = $container->get(FormHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TypeOfLicenceController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/VehiclesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/VehiclesControllerFactory.php
@@ -45,7 +45,7 @@ class VehiclesControllerFactory implements FactoryInterface
         $responseHelper = $container->get(ResponseHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VehiclesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/VehiclesDeclarationsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/VehiclesDeclarationsControllerFactory.php
@@ -25,7 +25,7 @@ class VehiclesDeclarationsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VehiclesDeclarationsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class VehiclesDeclarationsControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VehiclesDeclarationsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/VehiclesPsvControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/VehiclesPsvControllerFactory.php
@@ -29,7 +29,7 @@ class VehiclesPsvControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VehiclesPsvController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -43,7 +43,7 @@ class VehiclesPsvControllerFactory implements FactoryInterface
         $guidanceHelper = $container->get(GuidanceHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VehiclesPsvController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Application/WithdrawControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Application/WithdrawControllerFactory.php
@@ -23,7 +23,7 @@ class WithdrawControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): WithdrawController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class WithdrawControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $restrictionHelper = $container->get(RestrictionHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new WithdrawController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/AddressesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/AddressesControllerFactory.php
@@ -22,14 +22,14 @@ class AddressesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): AddressesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
         $scriptFactory = $container->get(ScriptFactory::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new AddressesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/BusinessDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/BusinessDetailsControllerFactory.php
@@ -25,7 +25,7 @@ class BusinessDetailsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): BusinessDetailsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class BusinessDetailsControllerFactory implements FactoryInterface
         $identityProvider = $container->get(IdentityProviderInterface::class);
         $tableFactory = $container->get(TableFactory::class);
         $fileUploadHelper = $container->get(FileUploadHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new BusinessDetailsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/BusinessTypeControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/BusinessTypeControllerFactory.php
@@ -39,7 +39,7 @@ class BusinessTypeControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $lvaAdapter = $container->get(GenericBusinessTypeAdapter::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new BusinessTypeController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/CommunityLicencesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/CommunityLicencesControllerFactory.php
@@ -24,7 +24,7 @@ class CommunityLicencesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): CommunityLicencesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -33,7 +33,7 @@ class CommunityLicencesControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $commandService = $container->get(CommandService::class);
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new CommunityLicencesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/ConditionsUndertakingsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/ConditionsUndertakingsControllerFactory.php
@@ -23,7 +23,7 @@ class ConditionsUndertakingsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ConditionsUndertakingsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -31,7 +31,7 @@ class ConditionsUndertakingsControllerFactory implements FactoryInterface
         $formServiceManager = $container->get(FormServiceManager::class);
         $tableFactory = $container->get(TableFactory::class);
         $lvaAdapter = $container->get(LicenceConditionsUndertakingsAdapter::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ConditionsUndertakingsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/DiscsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/DiscsControllerFactory.php
@@ -33,7 +33,7 @@ class DiscsControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $guidanceHelper = $container->get(GuidanceHelperService::class);
         $scriptFactory  = $container->get(ScriptFactory::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new DiscsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/OperatingCentresControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/OperatingCentresControllerFactory.php
@@ -25,7 +25,7 @@ class OperatingCentresControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): OperatingCentresController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class OperatingCentresControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $variationLvaService = $container->get(VariationLvaService::class);
         $uploadHelper = $container->get(FileUploadHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new OperatingCentresController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/OverviewControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/OverviewControllerFactory.php
@@ -21,12 +21,12 @@ class OverviewControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): OverviewController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $applicationOverviewHelper = $container->get(LicenceOverviewHelperService::class);
         $formHelper = $container->get(FormHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
 
         return new OverviewController(

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/PeopleControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/PeopleControllerFactory.php
@@ -25,7 +25,7 @@ class PeopleControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): PeopleController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class PeopleControllerFactory implements FactoryInterface
         $guidanceHelper = $container->get(GuidanceHelperService::class);
         $lvaAdapter = $container->get(LicencePeopleAdapter::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new PeopleController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/SafetyControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/SafetyControllerFactory.php
@@ -24,7 +24,7 @@ class SafetyControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): SafetyController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -33,7 +33,7 @@ class SafetyControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $scriptFactory = $container->get(ScriptFactory::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new SafetyController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TaxiPhvControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TaxiPhvControllerFactory.php
@@ -24,7 +24,7 @@ class TaxiPhvControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TaxiPhvController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -33,7 +33,7 @@ class TaxiPhvControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $scriptFactory = $container->get(ScriptFactory::class);
         $translationHelper = $container->get(TranslationHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TaxiPhvController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TrailersControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TrailersControllerFactory.php
@@ -25,7 +25,7 @@ class TrailersControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TrailersController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class TrailersControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $dateHelper = $container->get(DateHelperService::class);
         $querySender = $container->get(QuerySender::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TrailersController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TransportManagersControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TransportManagersControllerFactory.php
@@ -27,7 +27,7 @@ class TransportManagersControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TransportManagersController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -39,7 +39,7 @@ class TransportManagersControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $transportManagerHelper = $container->get(TransportManagerHelperService::class);
         $lvaAdapter = $container->get(LicenceTransportManagerAdapter::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TransportManagersController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TypeOfLicenceControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/TypeOfLicenceControllerFactory.php
@@ -23,7 +23,7 @@ class TypeOfLicenceControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TypeOfLicenceController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class TypeOfLicenceControllerFactory implements FactoryInterface
         $formServiceManager = $container->get(FormServiceManager::class);
         $formHelper = $container->get(FormHelperService::class);
         $variationLvaService = $container->get(VariationLvaService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TypeOfLicenceController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/VariationControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/VariationControllerFactory.php
@@ -22,14 +22,14 @@ class VariationControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VariationController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $processingCreateVariation = $container->get(CreateVariationProcessingService::class);
         $formHelper = $container->get(FormHelperService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VariationController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/VehiclesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/VehiclesControllerFactory.php
@@ -28,7 +28,7 @@ class VehiclesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VehiclesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -41,7 +41,7 @@ class VehiclesControllerFactory implements FactoryInterface
         $variationLvaService = $container->get(VariationLvaService::class);
         $goodsVehicleMapper = $container->get(GoodsVehiclesVehicle::class);
         $responseHelper = $container->get(ResponseHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VehiclesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/VehiclesPsvControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Licence/VehiclesPsvControllerFactory.php
@@ -27,7 +27,7 @@ class VehiclesPsvControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VehiclesPsvController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -39,7 +39,7 @@ class VehiclesPsvControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $urlHelper = $container->get(UrlHelperService::class);
         $responseHelper = $container->get(ResponseHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VehiclesPsvController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/AddressesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/AddressesControllerFactory.php
@@ -23,7 +23,7 @@ class AddressesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): AddressesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -31,7 +31,7 @@ class AddressesControllerFactory implements FactoryInterface
         $formServiceManager = $container->get(FormServiceManager::class);
         $scriptFactory = $container->get(ScriptFactory::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new AddressesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/BusinessDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/BusinessDetailsControllerFactory.php
@@ -26,7 +26,7 @@ class BusinessDetailsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): BusinessDetailsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -37,7 +37,7 @@ class BusinessDetailsControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $identityProvider = $container->get(IdentityProviderInterface::class);
         $fileUploadHelper = $container->get(FileUploadHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new BusinessDetailsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/BusinessTypeControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/BusinessTypeControllerFactory.php
@@ -28,7 +28,7 @@ class BusinessTypeControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): BusinessTypeController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -41,7 +41,7 @@ class BusinessTypeControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $lvaAdapter = $container->get(GenericBusinessTypeAdapter::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new BusinessTypeController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/CommunityLicencesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/CommunityLicencesControllerFactory.php
@@ -25,7 +25,7 @@ class CommunityLicencesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): CommunityLicencesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class CommunityLicencesControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $commandService = $container->get(CommandService::class);
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new CommunityLicencesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/ConditionsUndertakingsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/ConditionsUndertakingsControllerFactory.php
@@ -24,7 +24,7 @@ class ConditionsUndertakingsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ConditionsUndertakingsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -33,7 +33,7 @@ class ConditionsUndertakingsControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $stringHelper = $container->get(StringHelperService::class);
         $lvaAdapter = $container->get(VariationConditionsUndertakingsAdapter::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ConditionsUndertakingsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/ConvictionsPenaltiesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/ConvictionsPenaltiesControllerFactory.php
@@ -24,7 +24,7 @@ class ConvictionsPenaltiesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ConvictionsPenaltiesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -33,7 +33,7 @@ class ConvictionsPenaltiesControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $scriptFactory = $container->get(ScriptFactory::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ConvictionsPenaltiesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/DeclarationsInternalControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/DeclarationsInternalControllerFactory.php
@@ -22,14 +22,14 @@ class DeclarationsInternalControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): DeclarationsInternalController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new DeclarationsInternalController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/DiscsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/DiscsControllerFactory.php
@@ -25,7 +25,7 @@ class DiscsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): DiscsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class DiscsControllerFactory implements FactoryInterface
         $guidanceHelper = $container->get(GuidanceHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $scriptFactory  = $container->get(ScriptFactory::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new DiscsController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/FinancialEvidenceControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/FinancialEvidenceControllerFactory.php
@@ -27,7 +27,7 @@ class FinancialEvidenceControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): FinancialEvidenceController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $tableFactory = $container->get(TableFactory::class);
@@ -39,7 +39,7 @@ class FinancialEvidenceControllerFactory implements FactoryInterface
         $transferAnnotationBuilder = $container->get(AnnotationBuilder::class);
         $lvaAdapter = $container->get(VariationFinancialEvidenceAdapter::class);
         $uploadHelper = $container->get(FileUploadHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new FinancialEvidenceController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/FinancialHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/FinancialHistoryControllerFactory.php
@@ -24,7 +24,7 @@ class FinancialHistoryControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): FinancialHistoryController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -33,7 +33,7 @@ class FinancialHistoryControllerFactory implements FactoryInterface
         $dataHelper = $container->get(DataHelperService::class);
         $fileUploadHelper = $container->get(FileUploadHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new FinancialHistoryController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/GrantControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/GrantControllerFactory.php
@@ -31,7 +31,7 @@ class GrantControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new GrantController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/InterimControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/InterimControllerFactory.php
@@ -24,7 +24,7 @@ class InterimControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): InterimController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -33,7 +33,7 @@ class InterimControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         $stringHelper = $container->get(StringHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new InterimController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/LicenceHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/LicenceHistoryControllerFactory.php
@@ -24,7 +24,7 @@ class LicenceHistoryControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LicenceHistoryController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -33,7 +33,7 @@ class LicenceHistoryControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $tableFactory = $container->get(TableFactory::class);
         $formHelper = $container->get(FormHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new LicenceHistoryController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/OperatingCentresControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/OperatingCentresControllerFactory.php
@@ -26,7 +26,7 @@ class OperatingCentresControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): OperatingCentresController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -37,7 +37,7 @@ class OperatingCentresControllerFactory implements FactoryInterface
         $variationLvaService = $container->get(VariationLvaService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $uploadHelper = $container->get(FileUploadHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new OperatingCentresController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/OverviewControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/OverviewControllerFactory.php
@@ -23,14 +23,14 @@ class OverviewControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): OverviewController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $applicationOverviewHelper = $container->get(ApplicationOverviewHelperService::class);
         $formHelper = $container->get(FormHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
 
         return new OverviewController(

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/PeopleControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/PeopleControllerFactory.php
@@ -37,7 +37,7 @@ class PeopleControllerFactory implements FactoryInterface
         $stringHelper = $container->get(StringHelperService::class);
         $lvaAdapter = $container->get(VariationPeopleAdapter::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new PeopleController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/PublishControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/PublishControllerFactory.php
@@ -22,13 +22,13 @@ class PublishControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): PublishController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
 
         return new PublishController(

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/RefuseControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/RefuseControllerFactory.php
@@ -23,7 +23,7 @@ class RefuseControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): RefuseController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class RefuseControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new RefuseController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/ReviveApplicationControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/ReviveApplicationControllerFactory.php
@@ -23,7 +23,7 @@ class ReviveApplicationControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ReviveApplicationController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class ReviveApplicationControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new ReviveApplicationController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/SafetyControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/SafetyControllerFactory.php
@@ -25,7 +25,7 @@ class SafetyControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): SafetyController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class SafetyControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new SafetyController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/SubmitControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/SubmitControllerFactory.php
@@ -23,7 +23,7 @@ class SubmitControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): SubmitController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class SubmitControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new SubmitController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/TaxiPhvControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/TaxiPhvControllerFactory.php
@@ -25,7 +25,7 @@ class TaxiPhvControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TaxiPhvController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -35,7 +35,7 @@ class TaxiPhvControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $translationHelper = $container->get(TranslationHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TaxiPhvController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/TransportManagersControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/TransportManagersControllerFactory.php
@@ -41,7 +41,7 @@ class TransportManagersControllerFactory implements FactoryInterface
         $transportManagerHelper = $container->get(TransportManagerHelperService::class);
         $lvaAdapter = $container->get(VariationTransportManagerAdapter::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TransportManagersController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/TypeOfLicenceControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/TypeOfLicenceControllerFactory.php
@@ -23,7 +23,7 @@ class TypeOfLicenceControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TypeOfLicenceController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class TypeOfLicenceControllerFactory implements FactoryInterface
         $formServiceManager = $container->get(FormServiceManager::class);
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new TypeOfLicenceController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/VehiclesControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/VehiclesControllerFactory.php
@@ -29,7 +29,7 @@ class VehiclesControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VehiclesController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelperService = $container->get(FormHelperService::class);
@@ -43,7 +43,7 @@ class VehiclesControllerFactory implements FactoryInterface
         $guidanceHelper = $container->get(GuidanceHelperService::class);
         $variationLvaService = $container->get(VariationLvaService::class);
         $goodeVehiclesVehicle = $container->get(GoodsVehiclesVehicle::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VehiclesController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/VehiclesDeclarationsControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/VehiclesDeclarationsControllerFactory.php
@@ -24,7 +24,7 @@ class VehiclesDeclarationsControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VehiclesDeclarationsController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -32,7 +32,7 @@ class VehiclesDeclarationsControllerFactory implements FactoryInterface
         $scriptFactory = $container->get(ScriptFactory::class);
         $dataHelper = $container->get(DataHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
 
         return new VehiclesDeclarationsController(

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/VehiclesPsvControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/VehiclesPsvControllerFactory.php
@@ -28,7 +28,7 @@ class VehiclesPsvControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): VehiclesPsvController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $formHelper = $container->get(FormHelperService::class);
@@ -41,7 +41,7 @@ class VehiclesPsvControllerFactory implements FactoryInterface
         $translationHelper = $container->get(TranslationHelperService::class);
         $guidanceHelper = $container->get(GuidanceHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new VehiclesPsvController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/WithdrawControllerFactory.php
+++ b/module/Olcs/src/Controller/Lva/Factory/Controller/Variation/WithdrawControllerFactory.php
@@ -23,7 +23,7 @@ class WithdrawControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): WithdrawController
     {
-        
+
         $niTextTranslationUtil = $container->get(NiTextTranslation::class);
         $authService = $container->get(AuthorizationService::class);
         $flashMessengerHelper = $container->get(FlashMessengerHelperService::class);
@@ -31,7 +31,7 @@ class WithdrawControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $stringHelper = $container->get(StringHelperService::class);
         $formServiceManager = $container->get(FormServiceManager::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         return new WithdrawController(
             $niTextTranslationUtil,

--- a/module/Olcs/src/Controller/Operator/OperatorIrfoDetailsControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorIrfoDetailsControllerFactory.php
@@ -22,7 +22,7 @@ class OperatorIrfoDetailsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OperatorIrfoDetailsController(

--- a/module/Olcs/src/Controller/Operator/OperatorIrfoGvPermitsControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorIrfoGvPermitsControllerFactory.php
@@ -22,7 +22,7 @@ class OperatorIrfoGvPermitsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OperatorIrfoGvPermitsController(

--- a/module/Olcs/src/Controller/Operator/OperatorIrfoPsvAuthorisationsControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorIrfoPsvAuthorisationsControllerFactory.php
@@ -22,7 +22,7 @@ class OperatorIrfoPsvAuthorisationsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OperatorIrfoPsvAuthorisationsController(

--- a/module/Olcs/src/Controller/Operator/OperatorLicencesApplicationsControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorLicencesApplicationsControllerFactory.php
@@ -23,7 +23,7 @@ class OperatorLicencesApplicationsControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $operAppStatusService = $container->get(ApplicationStatus::class);

--- a/module/Olcs/src/Controller/Operator/OperatorPeopleControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorPeopleControllerFactory.php
@@ -22,7 +22,7 @@ class OperatorPeopleControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OperatorPeopleController(

--- a/module/Olcs/src/Controller/Operator/OperatorProcessingNoteControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorProcessingNoteControllerFactory.php
@@ -22,7 +22,7 @@ class OperatorProcessingNoteControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OperatorProcessingNoteController(

--- a/module/Olcs/src/Controller/Operator/OperatorUsersControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorUsersControllerFactory.php
@@ -22,7 +22,7 @@ class OperatorUsersControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new OperatorUsersController(

--- a/module/Olcs/src/Controller/Operator/Processing/ReadHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/Processing/ReadHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class ReadHistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReadHistoryController(

--- a/module/Olcs/src/Controller/Operator/UnlicensedOperatorVehiclesControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/UnlicensedOperatorVehiclesControllerFactory.php
@@ -22,7 +22,7 @@ class UnlicensedOperatorVehiclesControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new UnlicensedOperatorVehiclesController(

--- a/module/Olcs/src/Controller/Sla/CaseDocumentSlaTargetDateControllerFactory.php
+++ b/module/Olcs/src/Controller/Sla/CaseDocumentSlaTargetDateControllerFactory.php
@@ -22,7 +22,7 @@ class CaseDocumentSlaTargetDateControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new CaseDocumentSlaTargetDateController(

--- a/module/Olcs/src/Controller/Sla/LicenceDocumentSlaTargetDateControllerFactory.php
+++ b/module/Olcs/src/Controller/Sla/LicenceDocumentSlaTargetDateControllerFactory.php
@@ -22,7 +22,7 @@ class LicenceDocumentSlaTargetDateControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new LicenceDocumentSlaTargetDateController(

--- a/module/Olcs/src/Controller/Sla/RevocationsSlaControllerFactory.php
+++ b/module/Olcs/src/Controller/Sla/RevocationsSlaControllerFactory.php
@@ -22,7 +22,7 @@ class RevocationsSlaControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new RevocationsSlaController(

--- a/module/Olcs/src/Controller/TransportManager/Details/TransportManagerDetailsCompetenceControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/Details/TransportManagerDetailsCompetenceControllerFactory.php
@@ -26,7 +26,7 @@ class TransportManagerDetailsCompetenceControllerFactory implements FactoryInter
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $transferAnnotationBuilder = $container->get(TransferAnnotationBuilder::class);

--- a/module/Olcs/src/Controller/TransportManager/Details/TransportManagerDetailsDetailControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/Details/TransportManagerDetailsDetailControllerFactory.php
@@ -22,7 +22,7 @@ class TransportManagerDetailsDetailControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new TransportManagerDetailsDetailController(

--- a/module/Olcs/src/Controller/TransportManager/Details/TransportManagerDetailsEmploymentControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/Details/TransportManagerDetailsEmploymentControllerFactory.php
@@ -22,7 +22,7 @@ class TransportManagerDetailsEmploymentControllerFactory implements FactoryInter
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new TransportManagerDetailsEmploymentController(

--- a/module/Olcs/src/Controller/TransportManager/HistoricTm/HistoricTmControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/HistoricTm/HistoricTmControllerFactory.php
@@ -22,7 +22,7 @@ class HistoricTmControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new HistoricTmController(

--- a/module/Olcs/src/Controller/TransportManager/Processing/HistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/Processing/HistoryControllerFactory.php
@@ -23,7 +23,7 @@ class HistoryControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         $tableFactory = $container->get(TableFactory::class);

--- a/module/Olcs/src/Controller/TransportManager/Processing/PublicationControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/Processing/PublicationControllerFactory.php
@@ -22,7 +22,7 @@ class PublicationControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new PublicationController(

--- a/module/Olcs/src/Controller/TransportManager/Processing/ReadHistoryControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/Processing/ReadHistoryControllerFactory.php
@@ -22,7 +22,7 @@ class ReadHistoryControllerFactory implements FactoryInterface
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new ReadHistoryController(

--- a/module/Olcs/src/Controller/TransportManager/Processing/TransportManagerProcessingNoteControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/Processing/TransportManagerProcessingNoteControllerFactory.php
@@ -22,7 +22,7 @@ class TransportManagerProcessingNoteControllerFactory implements FactoryInterfac
         $flashMessengerHelperService = $container->get(FlashMessengerHelperService::class);
         assert($flashMessengerHelperService instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new TransportManagerProcessingNoteController(

--- a/module/Olcs/src/Controller/TransportManager/TransportManagerCaseControllerFactory.php
+++ b/module/Olcs/src/Controller/TransportManager/TransportManagerCaseControllerFactory.php
@@ -22,7 +22,7 @@ class TransportManagerCaseControllerFactory implements FactoryInterface
         $flashMessenger = $container->get(FlashMessengerHelperService::class);
         assert($flashMessenger instanceof FlashMessengerHelperService);
 
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
         return new TransportManagerCaseController(

--- a/module/Olcs/src/Listener/RouteParam/Application.php
+++ b/module/Olcs/src/Listener/RouteParam/Application.php
@@ -392,7 +392,7 @@ class Application implements ListenerAggregateInterface, FactoryInterface
         $this->setAnnotationBuilder($container->get('TransferAnnotationBuilder'));
         $this->setQueryService($container->get('QueryService'));
         $this->setViewHelperManager($container->get('ViewHelperManager'));
-        $this->setNavigationService($container->get('Navigation'));
+        $this->setNavigationService($container->get('navigation'));
         $this->setSidebarNavigationService($container->get('right-sidebar'));
         $this->setMarkerService($container->get(\Olcs\Service\Marker\MarkerService::class));
         $this->setApplicationService($container->get(\Common\Service\Data\Application::class));

--- a/module/Olcs/src/Listener/RouteParam/BusRegId.php
+++ b/module/Olcs/src/Listener/RouteParam/BusRegId.php
@@ -135,7 +135,7 @@ class BusRegId implements ListenerAggregateInterface, FactoryInterface
         $this->setAnnotationBuilder($container->get('TransferAnnotationBuilder'));
         $this->setQueryService($container->get('QueryService'));
         $this->setViewHelperManager($container->get('ViewHelperManager'));
-        $this->setNavigationService($container->get('Navigation'));
+        $this->setNavigationService($container->get('navigation'));
         return $this;
     }
 }

--- a/module/Olcs/src/Listener/RouteParam/Cases.php
+++ b/module/Olcs/src/Listener/RouteParam/Cases.php
@@ -36,7 +36,7 @@ class Cases implements ListenerAggregateInterface, FactoryInterface
 
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $this->navigationService = $container->get('Navigation');
+        $this->navigationService = $container->get('navigation');
         $this->annotationBuilder = $container->get(AnnotationBuilder::class);
         $this->queryService = $container->get('QueryService');
         $this->viewHelperManager = $container->get('ViewHelperManager');

--- a/module/Olcs/src/Listener/RouteParam/IrhpApplicationFurniture.php
+++ b/module/Olcs/src/Listener/RouteParam/IrhpApplicationFurniture.php
@@ -120,7 +120,7 @@ class IrhpApplicationFurniture implements
         $this->setQuerySender($container->get('QuerySender'));
         $this->setCommandSender($container->get('CommandSender'));
         $this->setViewHelperManager($container->get('ViewHelperManager'));
-        $this->setNavigationService($container->get('Navigation'));
+        $this->setNavigationService($container->get('navigation'));
         $this->setSidebarNavigationService($container->get('right-sidebar'));
         $this->setApplicationService($container->get('Application'));
 

--- a/module/Olcs/src/Listener/RouteParam/Licence.php
+++ b/module/Olcs/src/Listener/RouteParam/Licence.php
@@ -551,7 +551,7 @@ class Licence implements ListenerAggregateInterface, FactoryInterface
         $this->setViewHelperManager($container->get('ViewHelperManager'));
         $this->setLicenceService($container->get('DataServiceManager')->get('Common\Service\Data\Licence'));
         $this->setNavigationService($container->get('right-sidebar'));
-        $this->setMainNavigationService($container->get('Navigation'));
+        $this->setMainNavigationService($container->get('navigation'));
         $this->setMarkerService($container->get(MarkerService::class));
         $this->setAnnotationBuilderService($container->get('TransferAnnotationBuilder'));
         $this->setQueryService($container->get('QueryService'));

--- a/module/Olcs/src/Listener/RouteParam/Organisation.php
+++ b/module/Olcs/src/Listener/RouteParam/Organisation.php
@@ -122,7 +122,7 @@ class Organisation implements ListenerAggregateInterface, FactoryInterface
         $this->queryService = $container->get('QueryService');
         $this->sidebarNavigationService = $container->get('right-sidebar');
         $this->markerService = $container->get(\Olcs\Service\Marker\MarkerService::class);
-        $this->navigationPlugin = $container->get('ViewHelperManager')->get('Navigation');
+        $this->navigationPlugin = $container->get('navigation');
         return $this;
     }
 }

--- a/test/Admin/src/Listener/RouteParam/IrhpPermitAdminFurnitureTest.php
+++ b/test/Admin/src/Listener/RouteParam/IrhpPermitAdminFurnitureTest.php
@@ -277,7 +277,7 @@ class IrhpPermitAdminFurnitureTest extends TestCase
         $mockSl->shouldReceive('get')->with('ViewHelperManager')->andReturn($mockViewHelperManager);
         $mockSl->shouldReceive('get')->with('QuerySender')->andReturn($mockQuerySender);
         $mockSl->shouldReceive('get')->with('CommandSender')->andReturn($mockCommandSender);
-        $mockSl->shouldReceive('get')->with('Navigation')->andReturn($mockNavigation);
+        $mockSl->shouldReceive('get')->with('navigation')->andReturn($mockNavigation);
 
         $sut = new IrhpPermitAdminFurniture();
         $service = $sut->__invoke($mockSl, IrhpPermitAdminFurniture::class);

--- a/test/Olcs/src/Controller/Application/ApplicationProcessingOverviewControllerTest.php
+++ b/test/Olcs/src/Controller/Application/ApplicationProcessingOverviewControllerTest.php
@@ -47,7 +47,7 @@ class ApplicationProcessingOverviewControllerTest extends MockeryTestCase
         $mockComplaintsHelper = m::mock(ComplaintsHelperService::class);
         $mockFlashMessengerHelper = m::mock(FlashMessengerHelperService::class);
         $mockRouter = m::mock(TreeRouteStack::class);
-        $mockNavigation = m::mock('Navigation');
+        $mockNavigation = m::mock('navigation');
 
         $controller = new ApplicationProcessingOverviewController(
             $mockScriptFactory,

--- a/test/Olcs/src/Controller/Lva/Application/ConditionsUndertakingsControllerTest.php
+++ b/test/Olcs/src/Controller/Lva/Application/ConditionsUndertakingsControllerTest.php
@@ -43,7 +43,7 @@ class ConditionsUndertakingsControllerTest extends AbstractLvaControllerTestCase
         $this->mockStringHelper = m::mock(StringHelperService::class);
         $this->mockLvaAdapter = m::mock(ApplicationConditionsUndertakingsAdapter::class);
         $this->mockRestrictionHelper = m::mock(RestrictionHelperService::class);
-        $this->mockNavigation = m::mock('Navigation');
+        $this->mockNavigation = m::mock('navigation');
 
         $this->mockController(
             ConditionsUndertakingsController::class,

--- a/test/Olcs/src/Controller/Lva/Licence/OverviewControllerTest.php
+++ b/test/Olcs/src/Controller/Lva/Licence/OverviewControllerTest.php
@@ -39,7 +39,7 @@ class OverviewControllerTest extends AbstractLvaControllerTestCase
         $this->mockAuthService = m::mock(AuthorizationService::class);
         $this->mockLicenceOverviewHelper = m::mock(LicenceOverviewHelperService::class);
         $this->mockFormHelper = m::mock(FormHelperService::class);
-        $this->mockNavigation = m::mock('Navigation');
+        $this->mockNavigation = m::mock('navigation');
         $this->mockFlashMessenger = m::mock(FlashMessengerHelperService::class);
         $this->mockController(OverviewController::class, [
            $this->mockNiTextTranslationUtil,

--- a/test/Olcs/src/Listener/RouteParam/ApplicationTest.php
+++ b/test/Olcs/src/Listener/RouteParam/ApplicationTest.php
@@ -675,7 +675,7 @@ class ApplicationTest extends MockeryTestCase
 
         $mockSl = m::mock(ContainerInterface::class);
         $mockSl->shouldReceive('get')->with('ViewHelperManager')->andReturn($mockViewHelperManager);
-        $mockSl->shouldReceive('get')->with('Navigation')->andReturn($mockNavigationService);
+        $mockSl->shouldReceive('get')->with('navigation')->andReturn($mockNavigationService);
         $mockSl->shouldReceive('get')->with('right-sidebar')->andReturn($mockSidebar);
         $mockSl->shouldReceive('get')->with('TransferAnnotationBuilder')->andReturn($mockTransferAnnotationBuilder);
         $mockSl->shouldReceive('get')->with('QueryService')->andReturn($mockQueryService);

--- a/test/Olcs/src/Listener/RouteParam/BusRegIdTest.php
+++ b/test/Olcs/src/Listener/RouteParam/BusRegIdTest.php
@@ -141,7 +141,7 @@ class BusRegIdTest extends MockeryTestCase
 
         $mockSl = m::mock(ContainerInterface::class);
         $mockSl->shouldReceive('get')->with('ViewHelperManager')->andReturn($mockViewHelperManager);
-        $mockSl->shouldReceive('get')->with('Navigation')->andReturn($mockNavigation);
+        $mockSl->shouldReceive('get')->with('navigation')->andReturn($mockNavigation);
         $mockSl->shouldReceive('get')->with('TransferAnnotationBuilder')->andReturn($mockTransferAnnotationBuilder);
         $mockSl->shouldReceive('get')->with('QueryService')->andReturn($mockQueryService);
 

--- a/test/Olcs/src/Listener/RouteParam/CasesTest.php
+++ b/test/Olcs/src/Listener/RouteParam/CasesTest.php
@@ -145,7 +145,7 @@ class CasesTest extends MockeryTestCase
         $mockAnnotationBuilder = m::mock(AnnotationBuilder::class);
 
         $mockSl = m::mock(ContainerInterface::class);
-        $mockSl->shouldReceive('get')->with('Navigation')->andReturn($mockNavigation);
+        $mockSl->shouldReceive('get')->with('navigation')->andReturn($mockNavigation);
         $mockSl->shouldReceive('get')->with(AnnotationBuilder::class)->andReturn($mockAnnotationBuilder);
         $mockSl->shouldReceive('get')->with('QueryService')->andReturn($mockQueryService);
         $mockSl->shouldReceive('get')->with('ViewHelperManager')->andReturn($mockViewHelperManager);

--- a/test/Olcs/src/Listener/RouteParam/IrhpApplicationFurnitureTest.php
+++ b/test/Olcs/src/Listener/RouteParam/IrhpApplicationFurnitureTest.php
@@ -322,7 +322,7 @@ class IrhpApplicationFurnitureTest extends TestCase
         $mockSl->shouldReceive('get')->with('ViewHelperManager')->andReturn($mockViewHelperManager);
         $mockSl->shouldReceive('get')->with('QuerySender')->andReturn($mockQuerySender);
         $mockSl->shouldReceive('get')->with('CommandSender')->andReturn($mockCommandSender);
-        $mockSl->shouldReceive('get')->with('Navigation')->andReturn($mockNavigation);
+        $mockSl->shouldReceive('get')->with('navigation')->andReturn($mockNavigation);
         $mockSl->shouldReceive('get')->with('right-sidebar')->andReturn($mockSidebar);
         $mockSl->shouldReceive('get')->with('Application')->andReturn($mockApplication);
 

--- a/test/Olcs/src/Listener/RouteParam/LicenceTest.php
+++ b/test/Olcs/src/Listener/RouteParam/LicenceTest.php
@@ -596,7 +596,7 @@ class LicenceTest extends TestCase
         $mockSl->shouldReceive('get')->with(MarkerService::class)->andReturn($mockMarkerService);
         $mockSl->shouldReceive('get')->with('TransferAnnotationBuilder')->andReturn($mockAnnotationBuilder);
         $mockSl->shouldReceive('get')->with('QueryService')->andReturn($mockQueryService);
-        $mockSl->shouldReceive('get')->with('Navigation')->andReturn($mainNav);
+        $mockSl->shouldReceive('get')->with('navigation')->andReturn($mainNav);
 
         $sut = new Licence();
         $service = $sut->__invoke($mockSl, Licence::class);

--- a/test/Olcs/src/Listener/RouteParam/OrganisationTest.php
+++ b/test/Olcs/src/Listener/RouteParam/OrganisationTest.php
@@ -62,29 +62,23 @@ class OrganisationTest extends MockeryTestCase
         $this->mockSideBar = m::mock(AbstractContainer::class);
         $this->mocNavMenu = m::mock(AbstractContainer::class);
 
-        $mockNavPlugin = m::mock(Navigation::class)
+        $this->mockNavPlugin = m::mock(Navigation::class)
             ->shouldReceive('__invoke')
             ->with('navigation')
             ->andReturn($this->mocNavMenu)
             ->getMock();
 
-        $helperMngr = m::mock(HelperPluginManager::class)
-            ->shouldReceive('get')
-            ->once()
-            ->with('Navigation')
-            ->andReturn($mockNavPlugin)
-            ->getMock();
-
         $mockSl = m::mock(ContainerInterface::class);
         $mockSl->shouldReceive('get')
             ->andReturnUsing(
-                function ($class) use ($helperMngr) {
+                function ($class) {
                     $map = [
                         'TransferAnnotationBuilder' => $this->mockAnnotationBldr,
                         'QueryService' => $this->mockQuerySrv,
                         'right-sidebar' => $this->mockSideBar,
                         MarkerService::class => $this->mockMarkerSrv,
-                        'ViewHelperManager' => $helperMngr,
+                        'ViewHelperManager' => m::mock(HelperPluginManager::class),
+                        'navigation' => $this->mockNavPlugin,
                     ];
 
                     return $map[$class];


### PR DESCRIPTION
## Description

The projects were using a mix of `Navigation` and `navigation` resulting in two different objects - this caused issues with navigation as two different objects were being mutated and used.

I went with `navigation` even though it was a larger refactor due to that being the alias that is registered in the upstream package: https://github.com/laminas/laminas-navigation/blob/2f39ab2f929d23da89bbb4401efdccb6e72eaf68/src/ConfigProvider.php#L33.

Related issue:  https://dvsa.atlassian.net/browse/VOL-4900 & https://dvsa.atlassian.net/browse/VOL-4915

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
