### PR TITLE
fix: missed dataservices from dedupe

### DIFF
--- a/module/Admin/src/Controller/TaskAllocationRulesControllerFactory.php
+++ b/module/Admin/src/Controller/TaskAllocationRulesControllerFactory.php
@@ -2,6 +2,7 @@
 
 namespace Admin\Controller;
 
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\TranslationHelperService;
@@ -30,7 +31,7 @@ class TaskAllocationRulesControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         assert($tableFactory instanceof TableFactory);
 
-        $userListInternal = $container->get(UserListInternal::class);
+        $userListInternal = $container->get(PluginManager::class)->get(UserListInternal::class);
         assert($userListInternal instanceof UserListInternal);
 
         return new TaskAllocationRulesController(

--- a/module/Admin/src/Controller/TeamControllerFactory.php
+++ b/module/Admin/src/Controller/TeamControllerFactory.php
@@ -2,6 +2,7 @@
 
 namespace Admin\Controller;
 
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\TranslationHelperService;
@@ -35,7 +36,7 @@ class TeamControllerFactory implements FactoryInterface
         $tableFactory = $container->get(TableFactory::class);
         assert($tableFactory instanceof TableFactory);
 
-        $subCategory = $container->get(SubCategory::class);
+        $subCategory = $container->get(PluginManager::class)->get(SubCategory::class);
         assert($subCategory instanceof SubCategory);
 
         $userWithNameService = $container->get(UserWithName::class);

--- a/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingInspectionRequestControllerFactory.php
+++ b/module/Olcs/src/Controller/Application/Processing/ApplicationProcessingInspectionRequestControllerFactory.php
@@ -3,6 +3,7 @@
 namespace Olcs\Controller\Application\Processing;
 
 use Common\Service\Cqrs\Query\CachingQueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\TranslationHelperService;
@@ -34,7 +35,7 @@ class ApplicationProcessingInspectionRequestControllerFactory implements Factory
         $queryService = $container->get(CachingQueryService::class);
         assert($queryService instanceof CachingQueryService);
 
-        $operatingCentresForInspectionRequest = $container->get(OperatingCentresForInspectionRequest::class);
+        $operatingCentresForInspectionRequest = $container->get(PluginManager::class)->get(OperatingCentresForInspectionRequest::class);
 
         return new ApplicationProcessingInspectionRequestController(
             $translationHelper,

--- a/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingInspectionRequestControllerFactory.php
+++ b/module/Olcs/src/Controller/Licence/Processing/LicenceProcessingInspectionRequestControllerFactory.php
@@ -3,6 +3,7 @@
 namespace Olcs\Controller\Licence\Processing;
 
 use Common\Service\Cqrs\Query\QueryService;
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\TranslationHelperService;
@@ -28,7 +29,7 @@ class LicenceProcessingInspectionRequestControllerFactory implements FactoryInte
         $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
-        $setUpOcListboxService = $container->get(OperatingCentresForInspectionRequest::class);
+        $setUpOcListboxService = $container->get(PluginManager::class)->get(OperatingCentresForInspectionRequest::class);
         assert($setUpOcListboxService instanceof OperatingCentresForInspectionRequest);
 
         $annotationBuilderService = $container->get(AnnotationBuilder::class);

--- a/module/Olcs/src/Controller/Operator/OperatorLicencesApplicationsControllerFactory.php
+++ b/module/Olcs/src/Controller/Operator/OperatorLicencesApplicationsControllerFactory.php
@@ -2,6 +2,7 @@
 
 namespace Olcs\Controller\Operator;
 
+use Common\Service\Data\PluginManager;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\TranslationHelperService;
@@ -26,7 +27,7 @@ class OperatorLicencesApplicationsControllerFactory implements FactoryInterface
         $navigation = $container->get('navigation');
         assert($navigation instanceof Navigation);
 
-        $operAppStatusService = $container->get(ApplicationStatus::class);
+        $operAppStatusService = $container->get(PluginManager::class)->get(ApplicationStatus::class);
         assert($operAppStatusService instanceof ApplicationStatus);
 
         return new OperatorLicencesApplicationsController(


### PR DESCRIPTION
## Description

Fixes some errors from moving duped Data Services to correct plugin namespace

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
