### PR TITLE
fix: add `create_empty_option` to `CreateFeeDetails`

### DIFF
--- a/module/Olcs/src/Form/Model/Fieldset/CreateFeeDetails.php
+++ b/module/Olcs/src/Form/Model/Fieldset/CreateFeeDetails.php
@@ -28,7 +28,8 @@ class CreateFeeDetails
      * @Form\Options({
      *      "short-label":"fees.created_date",
      *      "label":"fees.created_date",
-     *      "label_attributes": {"id": "label-createdDate"}
+     *      "label_attributes": {"id": "label-createdDate"},
+     *      "create_empty_option": true,
      * })
      * @Form\Required(true)
      * @Form\Attributes({"required":false, "id":"createdDate"})


### PR DESCRIPTION
## Description

Add `create_empty_option` to the `createdDate` for the create fee form so that the Laminas element returns `null` instead of `0000-00-00`.

Related issue: https://dvsa.atlassian.net/browse/VOL-4923

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
