### PR TITLE
fix: tweak `CrudListener` priority to run before `DispatchListener`

### DIFF
--- a/module/Olcs/src/Controller/AbstractInternalController.php
+++ b/module/Olcs/src/Controller/AbstractInternalController.php
@@ -455,7 +455,7 @@ abstract class AbstractInternalController extends AbstractOlcsController
         $paramProvider->setParams($this->plugin('params'));
         $providedParameters = $this->modifyListQueryParameters($paramProvider->provideParameters());
         $response = $this->handleQuery($listDto::create($providedParameters));
-       
+
         if ($response->isOk()) {
             $data = $response->getResult();
             $this->listData = $data;
@@ -970,7 +970,7 @@ abstract class AbstractInternalController extends AbstractOlcsController
         parent::attachDefaultListeners();
 
         $listener = new CrudListener($this, $this->routeIdentifier, $this->crudConfig, $this->flashMessengerHelperService);
-        $this->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, [$listener, 'onDispatch']);
+        $this->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, [$listener, 'onDispatch'], 2);
 
         if (method_exists($this, 'setNavigationCurrentLocation')) {
             $this->getEventManager()->attach(MvcEvent::EVENT_DISPATCH, array($this, 'setNavigationCurrentLocation'), 6);


### PR DESCRIPTION
## Description

Most of the Laminas collections (lists) have gone from LIFO to FIFO. So as this worked before as it was the last to get injected into the EventManager. It's no longer the case on Laminas v3 hence why an explicit priority above the Laminas `DispatchListener`.

Related issue: https://dvsa.atlassian.net/browse/VOL-4925

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
