### PR TITLE
fix: restore modal titles in confirmation modals

### DIFF
--- a/module/Olcs/src/Controller/AbstractInternalController.php
+++ b/module/Olcs/src/Controller/AbstractInternalController.php
@@ -766,6 +766,7 @@ abstract class AbstractInternalController extends AbstractOlcsController
 
         if ($confirm instanceof ViewModel) {
             $this->placeholder()->setPlaceholder('pageTitle', $modalTitle);
+            $this->placeholder()->setPlaceholder('contentTitle', $modalTitle);
             return $this->viewBuilder()->buildView($confirm);
         }
 


### PR DESCRIPTION
## Description

Add `contentTitle` to placeholder to restore the old modal titles.

Related issue: https://dvsa.atlassian.net/browse/VOL-4941

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
