### PR TITLE
fix: add `VariationSchedule41Controller` factory mapping to service manager

### DIFF
--- a/module/Olcs/config/module.config.php
+++ b/module/Olcs/config/module.config.php
@@ -45,6 +45,7 @@ use Olcs\Controller\Factory\TaskControllerFactory;
 use Olcs\Controller\Factory\TransportManager\Details\TransportManagerDetailsPreviousHistoryControllerFactory;
 use Olcs\Controller\Factory\TransportManager\Processing\TransportManagerProcessingTaskControllerFactory;
 use Olcs\Controller\Factory\TransportManager\TransportManagerDocumentControllerFactory;
+use Olcs\Controller\Factory\Variation\VariationSchedule41ControllerFactory;
 use Olcs\Controller\Interfaces\ApplicationControllerInterface;
 use Olcs\Controller\Interfaces\BusRegControllerInterface;
 use Olcs\Controller\Interfaces\CaseControllerInterface;
@@ -81,6 +82,7 @@ use Olcs\Controller\TransportManager\Details\TransportManagerDetailsPreviousHist
 use Olcs\Controller\TransportManager\Processing\TransportManagerProcessingTaskController;
 use Olcs\Controller\TransportManager\TransportManagerController;
 use Olcs\Controller\TransportManager\TransportManagerDocumentController;
+use Olcs\Controller\Variation\VariationSchedule41Controller;
 use Olcs\Form\Element\SearchDateRangeFieldsetFactory;
 use Olcs\Form\Element\SearchFilterFieldsetFactory;
 use Olcs\Form\Element\SubmissionSections;
@@ -429,6 +431,7 @@ return array(
             \Olcs\Controller\SplitScreenController::class => SplitScreenControllerFactory::class,
             TransportManagerDocumentController::class => TransportManagerDocumentControllerFactory::class,
             TransportManagerDetailsPreviousHistoryController::class => TransportManagerDetailsPreviousHistoryControllerFactory::class,
+            VariationSchedule41Controller::class => VariationSchedule41ControllerFactory::class,
         ],
         'aliases' => [
             'LvaApplication' => Olcs\Controller\Lva\Application\OverviewController::class,
@@ -564,12 +567,12 @@ return array(
             'LicenceReadHistoryController' => 'Olcs\Controller\Licence\Processing\ReadHistoryController',
             'TransportManagerHistoryController' => TmCntr\Processing\HistoryController::class,
             'TransportManagerReadHistoryController' => 'Olcs\Controller\TransportManager\Processing\ReadHistoryController',
-            'ApplicationHistoryController' => ApplicationControllers\Processing\HistoryController::class,//'Olcs\Controller\Application\Processing\HistoryController',
-            'ApplicationReadHistoryController' => ApplicationControllers\Processing\ReadHistoryController::class,//'Olcs\Controller\Application\Processing\ReadHistoryController',
-            'OperatorReadHistoryController' => OperatorControllers\Processing\ReadHistoryController::class,//'Olcs\Controller\Operator\Processing\ReadHistoryController',
+            'ApplicationHistoryController' => ApplicationControllers\Processing\HistoryController::class,
+            'ApplicationReadHistoryController' => ApplicationControllers\Processing\ReadHistoryController::class,
+            'OperatorReadHistoryController' => OperatorControllers\Processing\ReadHistoryController::class,
             'CaseDocumentSlaTargetDateController' => CaseDocumentSlaTargetDateController::class ,
             'LicenceDocumentSlaTargetDateController' => LicenceDocumentSlaTargetDateController::class,
-            'IrhpDocsController' => 'Olcs\Controller\IrhpPermits\IrhpDocsController'
+            'IrhpDocsController' => 'Olcs\Controller\IrhpPermits\IrhpDocsController',
         ]
     ),
     'controller_plugins' => array(


### PR DESCRIPTION
## Description

Missing factory mapping for the `VariationSchedule41Controller`.

Related issue: https://dvsa.atlassian.net/browse/VOL-4952

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
