### PR TITLE
fix: fix `TypeError` in `PermitsReportController`

### DIFF
--- a/module/Admin/src/Controller/PermitsReportController.php
+++ b/module/Admin/src/Controller/PermitsReportController.php
@@ -9,6 +9,7 @@ use Admin\Form\Model\Form\PermitsReport;
 use Common\Form\Form;
 use Dvsa\Olcs\Transfer\Command\Permits\QueueReport;
 use Dvsa\Olcs\Transfer\Query\Permits\ReportList;
+use Laminas\Http\Response;
 use Laminas\View\Model\ViewModel;
 use Olcs\Controller\AbstractInternalController;
 use Olcs\Controller\Interfaces\LeftViewProvider;
@@ -22,9 +23,9 @@ class PermitsReportController extends AbstractInternalController implements Left
     /**
      * Process action - Index
      *
-     * @return ViewModel
+     * @return ViewModel|Response
      */
-    public function indexAction(): ViewModel
+    public function indexAction()
     {
         $form = $this->getForm(PermitsReport::class);
         $this->setSelectReportList($form);


### PR DESCRIPTION
## Description

The method can (and does) return `Response|ViewModel`, though this cannot be represented in return types in PHP 7.4 so needs to be removed.

Related issue: https://dvsa.atlassian.net/browse/VOL-4958

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
