### PR TITLE
fix: add `priority` to `RouteParams` to always run before controllers

### DIFF
--- a/module/Olcs/src/Module.php
+++ b/module/Olcs/src/Module.php
@@ -87,7 +87,7 @@ class Module
         $headerSearch->attach($eventManager);
 
         $routeParams = $e->getApplication()->getServiceManager()->get(RouteParams::class);
-        $eventManager->attach(MvcEvent::EVENT_DISPATCH, [$routeParams, 'onDispatch']);
+        $eventManager->attach(MvcEvent::EVENT_DISPATCH, [$routeParams, 'onDispatch'], 10);
 
         $eventManager->attach(
             MvcEvent::EVENT_ROUTE,


### PR DESCRIPTION
## Description

Listener lists have moved to FIFO from LIFO and the RouteParams now runs after the controller dispatch.

Related issue: https://dvsa.atlassian.net/browse/VOL-4957 & https://dvsa.atlassian.net/browse/VOL-4873

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
