### PR TITLE
fix: Add missing licence (and application) headers to a few messaging pages

### DIFF
--- a/module/Olcs/src/Controller/Messages/ApplicationConversationListController.php
+++ b/module/Olcs/src/Controller/Messages/ApplicationConversationListController.php
@@ -10,7 +10,9 @@ use Olcs\Controller\AbstractInternalController;
 use Olcs\Controller\Interfaces\ApplicationControllerInterface;
 use Olcs\Controller\Interfaces\LeftViewProvider;
 
-class ApplicationConversationListController extends AbstractInternalController implements LeftViewProvider, ApplicationControllerInterface, ToggleAwareInterface
+class ApplicationConversationListController
+    extends AbstractInternalController
+    implements LeftViewProvider, ApplicationControllerInterface, ToggleAwareInterface
 {
     protected $navigationId = 'application_conversations';
     protected $listVars = ['application'];

--- a/module/Olcs/src/Controller/Messages/ApplicationConversationMessagesController.php
+++ b/module/Olcs/src/Controller/Messages/ApplicationConversationMessagesController.php
@@ -7,7 +7,9 @@ namespace Olcs\Controller\Messages;
 use Olcs\Controller\Interfaces\ApplicationControllerInterface;
 use Olcs\Controller\Traits\ApplicationControllerTrait;
 
-class ApplicationConversationMessagesController extends AbstractConversationMessagesController implements ApplicationControllerInterface
+class ApplicationConversationMessagesController
+    extends AbstractConversationMessagesController
+    implements ApplicationControllerInterface
 {
     use ApplicationControllerTrait;
 

--- a/module/Olcs/src/Controller/Messages/ApplicationCreateConversationController.php
+++ b/module/Olcs/src/Controller/Messages/ApplicationCreateConversationController.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Olcs\Controller\Messages;
 
-class ApplicationCreateConversationController extends AbstractCreateConversationController
+use Olcs\Controller\Interfaces\ApplicationControllerInterface;
+
+class ApplicationCreateConversationController
+    extends AbstractCreateConversationController
+    implements ApplicationControllerInterface
 {
     protected $navigationId = 'application_conversations';
 

--- a/module/Olcs/src/Controller/Messages/LicenceConversationListController.php
+++ b/module/Olcs/src/Controller/Messages/LicenceConversationListController.php
@@ -10,7 +10,9 @@ use Olcs\Controller\AbstractInternalController;
 use Olcs\Controller\Interfaces\LeftViewProvider;
 use Olcs\Controller\Interfaces\LicenceControllerInterface;
 
-class LicenceConversationListController extends AbstractInternalController implements LeftViewProvider, LicenceControllerInterface, ToggleAwareInterface
+class LicenceConversationListController
+    extends AbstractInternalController
+    implements LeftViewProvider, LicenceControllerInterface, ToggleAwareInterface
 {
     protected $navigationId = 'conversations';
     protected $listVars = ['licence'];

--- a/module/Olcs/src/Controller/Messages/LicenceConversationMessagesController.php
+++ b/module/Olcs/src/Controller/Messages/LicenceConversationMessagesController.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Olcs\Controller\Messages;
 
-class LicenceConversationMessagesController extends AbstractConversationMessagesController
+use Olcs\Controller\Interfaces\LicenceControllerInterface;
+
+class LicenceConversationMessagesController
+    extends AbstractConversationMessagesController
+    implements LicenceControllerInterface
 {
     protected $navigationId = 'conversations';
     protected $topNavigationId = 'licence';

--- a/module/Olcs/src/Controller/Messages/LicenceCreateConversationController.php
+++ b/module/Olcs/src/Controller/Messages/LicenceCreateConversationController.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Olcs\Controller\Messages;
 
-class LicenceCreateConversationController extends AbstractCreateConversationController
+use Olcs\Controller\Interfaces\LicenceControllerInterface;
+
+class LicenceCreateConversationController
+    extends AbstractCreateConversationController
+    implements LicenceControllerInterface
 {
     protected $navigationId = 'conversations';
 


### PR DESCRIPTION
… pages

## Description

Add interfaces to add the licence/application header and sidebars to a few messaging pages where it was missing.

Related issue: [VOL-4921](https://dvsa.atlassian.net/browse/VOL-4921)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
