### PR TITLE
refactor:  Changed favicon path to align with olcs-selfserve.

### DIFF
--- a/module/Olcs/view/partials/head.phtml
+++ b/module/Olcs/view/partials/head.phtml
@@ -3,7 +3,7 @@
 {
     echo $this->headTitle(strip_tags($this->title));
     echo $this->headMeta()->appendName('viewport', 'width=device-width, initial-scale=1.0')->appendHttpEquiv('X-UA-Compatible', 'IE=edge');
-    echo $this->headLink(['rel' => 'icon', 'href' => $this->assetPath('/images/bitmap/favicon.ico'), 'type' => 'image/x-icon'], 'PREPEND');
+    echo $this->headLink(['rel' => 'icon', 'href' => $this->assetPath('/assets/images/favicon.ico'), 'type' => 'image/x-icon'], 'PREPEND');
     echo $this->headLink()->appendStylesheet($this->assetPath('/styles/' . $this->applicationName() . '.css'));
     echo $this->headScript();
 }


### PR DESCRIPTION
## Description

There was discrepancy in the favicon paths between `olcs-selfserve` and `olcs-internal`:
olcs-selfserve: `/static/public/assets/images/favicon.ico`
olcs-internal: `/static/public/images/bitmap/favicon.ico`
To ensure consistency and simplify maintenance, aligned the favicon path in `olcs-internal` with `olcs-selfserve`. 

This way, any changes made to olcs-static will automatically apply to both projects.

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
