### PR TITLE
fix: Reset pagination when filtering conversations based on status

### DIFF
--- a/module/Olcs/src/Controller/Messages/AbstractConversationListController.php
+++ b/module/Olcs/src/Controller/Messages/AbstractConversationListController.php
@@ -26,7 +26,12 @@ abstract class AbstractConversationListController extends AbstractInternalContro
      */
     public function getLeftView()
     {
+        $formAction = $this->url()->fromRoute(
+            $this->getEvent()->getRouteMatch()->getMatchedRouteName(),
+            $this->params()->fromRoute(),
+        );
         $filterForm = $this->getForm(ConversationFilter::class);
+        $filterForm->setAttribute('action', $formAction);
         $filterForm->setData($this->getRequest()->getQuery());
 
         $view = new ViewModel(['navigationId' => $this->navigationId]);


### PR DESCRIPTION
## Description

Pagination issue when using messages status filter

Related issue: [VOL-5178](https://dvsa.atlassian.net/browse/VOL-5178)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
