### PR TITLE
fix: Translation popup showing HTML rather then rendering

### DIFF
--- a/module/Admin/assets/js/inline/forms/translation-key-modal.js
+++ b/module/Admin/assets/js/inline/forms/translation-key-modal.js
@@ -25,20 +25,22 @@ $(function () {
             var current = " current";
             $.each(result.languages, function (idx, lang) {
                     var hideClass = (idx === "en_GB") ? "" : " js-hidden";
-                    var tabTemplate =
-                        ` < li id = "tab{idx}" class = "horizontal-navigation__item transKeyTab${current}" data - lang = "${idx}" style = "padding: 0px; margin: 0px;" >
-                            < a class = "govuk-link" id = "transKeyEnGB" href = "#" > ${lang.label} < / a >
-                       <  / li > `;
-                    var textAreaTemplate =
-                        ` < div class = "langFields field ${hideClass}" >
-                                < textarea name = "fields[translationsArray][${idx}]" id = "input-${idx}" class = "extra-long" > < / textarea >
-                        <  / div > `;
+                    var tabTemplate = `
+                        <li id="tab{idx}" class="horizontal-navigation__item transKeyTab${current}" data-lang="${idx}" style="padding: 0px; margin: 0px;">
+                            <a class="govuk-link" id="transKeyEnGB" href="#">${lang.label}</a>
+                       </li>
+                    `;
+                    var textAreaTemplate = `
+                        <div class="langFields field ${hideClass}">
+                                <textarea name="fields[translationsArray][${idx}]" id="input-${idx}" class="extra-long"></textarea>
+                        </div>
+                    `;
                     $("#languageTabs").append(tabTemplate);
                     fieldset.prepend(textAreaTemplate);
                     current = "";
             });
             fieldset.removeClass("hidden");
-            if (addedit == "edit") {
+            if (addedit === "edit") {
                 getTranslatedText();
             } else {
                 $("#mainForm").removeClass("js-hidden");

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
   <file>./config</file>
   <file>./test</file>
 
-  <extensions>php</extensions>
+  <arg name="extensions" value="php" />
   <exclude-pattern>*/vendor/*</exclude-pattern>
   <exclude-pattern>*\.(css|js)$</exclude-pattern>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,6 @@
   <file>./test</file>
 
   <arg name="extensions" value="php" />
-  <exclude-pattern>*/vendor/*</exclude-pattern>
-  <exclude-pattern>*\.(css|js)$</exclude-pattern>
 
   <rule ref="./vendor-bin/phpcs/vendor/dvsa/coding-standards/src/Profiles/DVSA/CS/ruleset.xml" />
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,7 @@
   <file>./test</file>
 
   <arg name="extensions" value="php" />
+  <exclude-pattern>*/vendor/*</exclude-pattern>
 
   <rule ref="./vendor-bin/phpcs/vendor/dvsa/coding-standards/src/Profiles/DVSA/CS/ruleset.xml" />
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
 
   <extensions>php</extensions>
   <exclude-pattern>*/vendor/*</exclude-pattern>
+  <exclude-pattern>*\.(css|js)$</exclude-pattern>
 
   <rule ref="./vendor-bin/phpcs/vendor/dvsa/coding-standards/src/Profiles/DVSA/CS/ruleset.xml" />
 </ruleset>


### PR DESCRIPTION
## Description

Unable to add or edit translation key due to form error due to rendering raw HTML

Related issue: [VOL-5198](https://dvsa.atlassian.net/browse/VOL-5198)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
