### PR TITLE
fix: Search link does not work on several pages

### DIFF
--- a/module/Olcs/src/Controller/SearchController.php
+++ b/module/Olcs/src/Controller/SearchController.php
@@ -7,6 +7,7 @@ use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Script\ScriptFactory;
 use Common\Service\Table\TableFactory;
+use Laminas\Http\Response;
 use Laminas\Session\Container;
 use Laminas\View\Helper\Placeholder;
 use Laminas\View\HelperPluginManager;
@@ -121,6 +122,26 @@ class SearchController extends AbstractController implements LeftViewProvider
     public function indexAction()
     {
         return $this->backAction();
+    }
+
+    public function oppositionAction(): Response
+    {
+        return $this->indexAction();
+    }
+
+    public function casesAction(): Response
+    {
+        return $this->indexAction();
+    }
+
+    public function documentsAction(): Response
+    {
+        return $this->indexAction();
+    }
+
+    public function feesAction(): Response
+    {
+        return $this->indexAction();
     }
 
     /**


### PR DESCRIPTION
## Description

Search does not work on several licence pages as it overrides the :action variable with invalid actions on the controller.

Related issue: [VOL-5307](https://dvsa.atlassian.net/browse/VOL-5307)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
