### PR TITLE
fix: Fixes some Readonly form elements that were not renamed in upgrade

### DIFF
--- a/module/Admin/src/Form/Model/Fieldset/FeeRateDetails.php
+++ b/module/Admin/src/Form/Model/Fieldset/FeeRateDetails.php
@@ -13,7 +13,7 @@ class FeeRateDetails
     use IdTrait;
 
     /**
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "ID:"
      * })
@@ -22,7 +22,7 @@ class FeeRateDetails
     public $idReadOnly;
 
     /**
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "Fee Type:"
      * })
@@ -31,7 +31,7 @@ class FeeRateDetails
     public $feeType;
 
     /**
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "Description:"
      * })

--- a/module/Admin/src/Form/Model/Fieldset/UserLoginSecurity.php
+++ b/module/Admin/src/Form/Model/Fieldset/UserLoginSecurity.php
@@ -42,7 +42,7 @@ class UserLoginSecurity
      * @Form\Options({"label":"Account locked"})
      * @Form\Required(false)
      * @Form\Attributes({"id":"locked", "required": false})
-     * @Form\Type("Common\Form\Elements\Types\Readonly")
+     * @Form\Type("Common\Form\Elements\Types\ReadonlyElement")
      */
     public $locked = null;
 
@@ -50,7 +50,7 @@ class UserLoginSecurity
      * @Form\Options({"label":"Password last reset"})
      * @Form\Required(false)
      * @Form\Attributes({"id":"passwordLastReset", "required": false})
-     * @Form\Type("Common\Form\Elements\Types\Readonly")
+     * @Form\Type("Common\Form\Elements\Types\ReadonlyElement")
      */
     public $passwordLastReset = null;
 

--- a/module/Olcs/src/Form/Model/Fieldset/CreatePermit.php
+++ b/module/Olcs/src/Form/Model/Fieldset/CreatePermit.php
@@ -23,7 +23,7 @@ class CreatePermit extends Base
     public $title = null;
 
     /**
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "Stock"
      * })
@@ -57,7 +57,7 @@ class CreatePermit extends Base
 
     /**
      * @Form\Type("Laminas\Form\Element\Hidden")
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "Current total vehicle authorization"
      * })

--- a/module/Olcs/src/Form/Model/Fieldset/IrhpApplication/Top.php
+++ b/module/Olcs/src/Form/Model/Fieldset/IrhpApplication/Top.php
@@ -11,7 +11,7 @@ use Laminas\Form\Annotation as Form;
 class Top extends \Olcs\Form\Model\Fieldset\Base
 {
     /**
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "Stock"
      * })
@@ -83,7 +83,7 @@ class Top extends \Olcs\Form\Model\Fieldset\Base
 
     /**
      * @Form\Type("Laminas\Form\Element\Hidden")
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "Current total vehicle authorization"
      * })

--- a/module/Olcs/src/Form/Model/Fieldset/IrhpBilateral/Top.php
+++ b/module/Olcs/src/Form/Model/Fieldset/IrhpBilateral/Top.php
@@ -47,7 +47,7 @@ class Top extends \Olcs\Form\Model\Fieldset\Base
 
     /**
      * @Form\Type("Laminas\Form\Element\Hidden")
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      * @Form\Options({
      *     "label": "Current total vehicle authorization"
      * })

--- a/module/Olcs/src/Form/Model/Fieldset/OperatorId.php
+++ b/module/Olcs/src/Form/Model/Fieldset/OperatorId.php
@@ -14,7 +14,7 @@ class OperatorId
     /**
      * @Form\Options({"label": "internal-operator-id"})
      * @Form\Name("operator-id")
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      */
     public $operatorId = null;
 }

--- a/module/Olcs/src/Form/Model/Fieldset/TransportManagerDetails.php
+++ b/module/Olcs/src/Form/Model/Fieldset/TransportManagerDetails.php
@@ -26,7 +26,7 @@ class TransportManagerDetails
     /**
      * @Form\Options({"label": "internal-transport-manager-id"})
      * @Form\Name("transport-manager-id")
-     * @Form\Type("\Common\Form\Elements\Types\Readonly")
+     * @Form\Type("\Common\Form\Elements\Types\ReadonlyElement")
      */
     public $transportManagerId = null;
 


### PR DESCRIPTION
## Description

Updates name of some elements renamed in php8 upgrade.

Related issue: [VOL-5435](https://dvsa.atlassian.net/browse/VOL-5435)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
