### PR TITLE
fix: fix TypeError when `selectedSectionsArray` is `null`

### DIFF
--- a/module/Olcs/view/sections/cases/pages/submission.phtml
+++ b/module/Olcs/view/sections/cases/pages/submission.phtml
@@ -12,11 +12,10 @@ $isInternalReadOnly = $this->placeholder('isInternalReadOnly')->getValue();
 
 $freetext = '';
 
-if (is_array($selectedSectionsArray)) {
-  $selectedIds = array_column($selectedSectionsArray, 'sectionId');
-} else {
-  $selectedIds = [];
-}
+$selectedSectionsArray = is_array($selectedSectionsArray) ? $selectedSectionsArray : [];
+
+$selectedIds = array_column($selectedSectionsArray, 'sectionId');
+
 foreach ($allSections as $sectionId => $sectionDescription) {
     if (array_key_exists($sectionId, $selectedSectionsArray))
     {


### PR DESCRIPTION
## Description

While this fixed the original issue, if `selectedSectionsArray` was `null` it threw a TypeError once it got to `array_key_exists`.

Related issue: https://dvsa.atlassian.net/browse/VOL-5438

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
