### PR TITLE
fix: VOL-5466 compatibility with latest Laminas form

### DIFF
--- a/module/Olcs/src/Controller/Cases/PublicInquiry/HearingController.php
+++ b/module/Olcs/src/Controller/Cases/PublicInquiry/HearingController.php
@@ -272,21 +272,8 @@ class HearingController extends AbstractInternalController implements CaseContro
         }
 
         $element = $form->get('fields')->get('hearingDate');
-        $pattern = $element->getOption('pattern');
+        $element->setOption('hint', $hint);
 
-        if (!empty($pattern)) {
-            if (strstr($pattern, '{{SLA_HINT}}')) {
-                $pattern = str_replace('{{SLA_HINT}}', '<p class="hint">' . $hint . '</p>', $pattern);
-
-                $element->setOption('pattern', $pattern);
-            } elseif (strstr($pattern, '</div>')) {
-                $pattern = str_replace('</div>', '<p class="hint">' . $hint . '</p></div>', $pattern);
-
-                $element->setOption('pattern', $pattern);
-            }
-        } else {
-            $this->setOption('hint', $hint);
-        }
         return $form;
     }
 }

--- a/module/Olcs/src/Form/Model/Fieldset/ImpoundingFields.php
+++ b/module/Olcs/src/Form/Model/Fieldset/ImpoundingFields.php
@@ -70,7 +70,6 @@ class ImpoundingFields
      *     "label": "Hearing date",
      *     "create_empty_option": true,
      *     "render_delimiters": true,
-     *     "pattern": "d MMMM y '</fieldset><fieldset><div class=""field""><label for=hearingDate>Hearing time</label>'HH:mm:ss'</div>'"
      * })
      * @Form\Filter("Laminas\Filter\DateTimeSelect", options={"null_on_empty":true})
      * @Form\Validator("ValidateIf",

--- a/module/Olcs/src/Form/Model/Fieldset/NonPiFields.php
+++ b/module/Olcs/src/Form/Model/Fieldset/NonPiFields.php
@@ -45,7 +45,6 @@ class NonPiFields extends CaseBase
      *     "label": "Meeting date",
      *     "create_empty_option": true,
      *     "render_delimiters": true,
-     *     "pattern": "d MMMM y '</fieldset><fieldset><div class=""field""><label for=""hearingDate"">Meeting time</label>'HH:mm:ss'</div>'",
      *     "field": "hearingDate"
      * })
      * @Form\Filter("DateTimeSelectNullifier")

--- a/module/Olcs/src/Form/Model/Fieldset/PublicInquiryHearingFields.php
+++ b/module/Olcs/src/Form/Model/Fieldset/PublicInquiryHearingFields.php
@@ -51,7 +51,6 @@ class PublicInquiryHearingFields extends Base
      *     "label": "Date of PI",
      *     "create_empty_option": true,
      *     "render_delimiters": true,
-     *     "pattern": "d MMMM y '{{SLA_HINT}}</fieldset><fieldset><div class=""field""><label for=""hearingDate"">Time of PI</label>'HH:mm:ss'</div>'",
      *     "category": "pi_hearing",
      *     "field": "hearingDate"
      * })
@@ -211,7 +210,6 @@ class PublicInquiryHearingFields extends Base
      *     "label": "Date adjournment agreed",
      *     "create_empty_option": true,
      *     "render_delimiters": true,
-     *     "pattern": "d MMMM y '</fieldset><fieldset><div class=""field""><label for=""adjournedDate"">Time adjournment agreed</label>'HH:mm:ss'</div>'",
      *     "field": "adjournedDate"
      * })
      * @Form\Filter({"name":"DateTimeSelect", "options":{"null_on_empty":true}})

--- a/module/Olcs/src/Form/Model/Fieldset/PublicInquirySlaMain.php
+++ b/module/Olcs/src/Form/Model/Fieldset/PublicInquirySlaMain.php
@@ -63,7 +63,6 @@ class PublicInquirySlaMain extends Base
      * @Form\Options({
      *     "label": "Date of written decision",
      *     "create_empty_option": true,
-     *     "pattern": "d MMMM y '{{SLA_HINT}}</fieldset>'",
      *     "render_delimiters": true,
      *     "category": "pi",
      *     "field": "tcWrittenDecisionDate"


### PR DESCRIPTION
## Description

Latest Laminas Form no longer allows for our custom HTML as it strips out <> characters. Returning formatting to the default INTL pattern.

Related issue: [VOL-5466](https://dvsa.atlassian.net/browse/VOL-5466)
