### PR TITLE
feat: Filter out unused irfo permit types from dropdown

### DIFF
--- a/module/Olcs/src/Service/Data/IrfoGvPermitType.php
+++ b/module/Olcs/src/Service/Data/IrfoGvPermitType.php
@@ -14,6 +14,8 @@ use Dvsa\Olcs\Transfer\Query\Irfo\IrfoGvPermitTypeList;
  */
 class IrfoGvPermitType extends AbstractDataService implements ListDataInterface
 {
+    public const UNUSED_TYPE_IDS = [5, 8, 12, 20, 15, 19, 16];
+
     /**
      * Format data
      *
@@ -70,10 +72,22 @@ class IrfoGvPermitType extends AbstractDataService implements ListDataInterface
             $this->setData('IrfoGvPermitType', false);
 
             if (isset($response->getResult()['results'])) {
-                $this->setData('IrfoGvPermitType', $response->getResult()['results']);
+                $this->setData('IrfoGvPermitType', $this->filterArrayById($response->getResult()['results']));
             }
         }
 
         return $this->getData('IrfoGvPermitType');
+    }
+
+    /**
+     * Filter unused IDs out of the array for display (cant remove from DB as 100s of permit records still reference the ID, but not needed for new permits)
+     *
+     * @param array $data Data
+     *
+     * @return array
+     */
+    public function filterArrayById(array $data): array
+    {
+        return array_filter($data, fn($record) => !in_array($record['id'], self::UNUSED_TYPE_IDS));
     }
 }

--- a/test/Olcs/src/Service/Data/IrfoGvPermitTypeTest.php
+++ b/test/Olcs/src/Service/Data/IrfoGvPermitTypeTest.php
@@ -54,7 +54,8 @@ class IrfoGvPermitTypeTest extends AbstractDataServiceTestCase
 
     public function testFetchListData()
     {
-        $results = ['results' => 'results'];
+        $results = ['results' => [['id' => 1],['id' => 2], ['id' => 12]]];
+        $expected = ['results' => [['id' => 1],['id' => 2]]];
 
         $this->transferAnnotationBuilder->shouldReceive('createQuery')
             ->with(m::type(Qry::class))
@@ -72,8 +73,8 @@ class IrfoGvPermitTypeTest extends AbstractDataServiceTestCase
 
         $this->mockHandleQuery($mockResponse);
 
-        $this->assertEquals($results['results'], $this->sut->fetchListData());
-        $this->assertEquals($results['results'], $this->sut->fetchListData());  //ensure data is cached
+        $this->assertEquals($expected['results'], $this->sut->fetchListData());  //ensure data is cached
+        $this->assertEquals($expected['results'], $this->sut->fetchListData());
     }
 
     public function testFetchLicenceDataWithException()
@@ -120,5 +121,27 @@ class IrfoGvPermitTypeTest extends AbstractDataServiceTestCase
             ['id' => 'val-3', 'description' => 'Value 3'],
         ];
         return $source;
+    }
+
+    public function testFilterArrayById()
+    {
+        $sourceData = [
+            ['id' => 1, 'description' => 'Valid Entry'],
+            ['id' => 5, 'description' => 'Should be filtered out'],
+            ['id' => 10, 'description' => 'Valid Entry'],
+            ['id' => 12, 'someField' => 'Should be filtered out'],
+            ['id' => 19, 'description' => 'Should be filtered out'],
+            ['id' => 22, 'otherField' => 'Valid Entry'],
+        ];
+
+        $expected = [
+            ['id' => 1, 'description' => 'Valid Entry'],
+            ['id' => 10, 'description' => 'Valid Entry'],
+            ['id' => 22, 'otherField' => 'Valid Entry']
+        ];
+
+        $filteredData = $this->sut->filterArrayById($sourceData);
+
+        $this->assertEquals($expected, array_values($filteredData), "Filtered array does not match expected output");
     }
 }


### PR DESCRIPTION
## Description

Filter out unused IRFO Permit types from drop down

Related issue: [VOL5009](https://dvsa.atlassian.net/browse/VOL-5009)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
