### PR TITLE
fix: Psalm & Redis IGBinary issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,12 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   static-analysis:
-    uses: static-analysis
-    with:
-      php-version: '8.2'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: static-analysis
+      with:
+        php-version: '8.2'
 
   tests:
     uses: dvsa/.github/.github/workflows/php-tests.yml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,30 +11,10 @@ jobs:
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-  psalm:
-
-    name: Psalm
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          coverage: none
-          extensions: mbstring, intl, redis-phpredis/phpredis@6.0.2
-          tools: vimeo/psalm, composer:v2
-        env:
-          REDIS_CONFIGURE_OPTS: --enable-redis-igbinary
-
-      - name: Install Composer dependancies
-        run: composer install --no-progress --no-interaction
-
-      - name: Execute Psalm
-        run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}
+  static-analysis:
+    uses: static-analysis
+    with:
+      php-version: '8.2'
 
   tests:
     uses: dvsa/.github/.github/workflows/php-tests.yml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
-env:
-  REDIS_CONFIGURE_OPTS: --enable-redis-igbinary
-
 jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-security.yml@main
@@ -15,7 +12,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   static-analysis:
-    uses: dvsa/.github/.github/workflows/php-static.yml@main
+    uses: dvsa/.github/.github/workflows/php-static.yml@redis-igbinary-test
     with:
       php-version: '8.2'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,17 +4,37 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * 1'
-  
+
 jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-security.yml@main
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-  static-analysis:
-    uses: dvsa/.github/.github/workflows/php-static.yml@redis-igbinary-test
-    with:
-      php-version: '8.2'
+  psalm:
+
+    name: Psalm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          extensions: mbstring, intl, redis-phpredis/phpredis
+          tools: vimeo/psalm, composer:v2
+        env:
+          REDIS_CONFIGURE_OPTS: --enable-redis-igbinary
+
+      - name: Install Composer dependancies
+        run: composer install --no-progress --no-interaction
+
+      - name: Execute Psalm
+        run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}
 
   tests:
     uses: dvsa/.github/.github/workflows/php-tests.yml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+env:
+  REDIS_CONFIGURE_OPTS: --enable-redis-igbinary
+
 jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-security.yml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          extensions: mbstring, intl, redis-phpredis/phpredis@latest
+          extensions: mbstring, intl, redis-phpredis/phpredis@6.0.2
           tools: vimeo/psalm, composer:v2
         env:
           REDIS_CONFIGURE_OPTS: --enable-redis-igbinary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * 1'
-    
 
 jobs:
   security:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          extensions: mbstring, intl, redis-phpredis/phpredis
+          extensions: mbstring, intl, redis-phpredis/phpredis@latest
           tools: vimeo/psalm, composer:v2
         env:
           REDIS_CONFIGURE_OPTS: --enable-redis-igbinary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,12 +12,9 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   static-analysis:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/workflows/static-analysis.yaml
-      with:
-        php-version: '8.2'
+    uses: ./.github/workflows/static-analysis
+    with:
+      php-version: '8.2'
 
   tests:
     uses: dvsa/.github/.github/workflows/php-tests.yml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * 1'
-
+  
 jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-security.yml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: ./.github/workflows/static-analysis
+    - uses: ./.github/workflows/static-analysis.yaml
       with:
         php-version: '8.2'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: static-analysis
+    - uses: ./.github/workflows/static-analysis
       with:
         php-version: '8.2'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   static-analysis:
-    uses: ./.github/workflows/static-analysis
+    uses: ./.github/workflows/static-analysis.yaml
     with:
       php-version: '8.2'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 0 * * 1'
+    
 
 jobs:
   security:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,83 @@
+name: Static analysis
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: false
+        type: string
+        default: 'latest'
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
+
+jobs:
+  phpstan:
+
+    name: PHPStan - ${{ inputs.php-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: none
+          tools: phpstan, composer:${{ inputs.composer-version }}
+
+      - name: Install Composer dependancies
+        run: composer install --no-progress --no-interaction
+
+      - name: Execute PHPStan
+        run: phpstan analyze --no-progress
+
+  php-codesniffer:
+
+    name: PHP-CodeSniffer - ${{ inputs.php-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: none
+          tools: php-cs-fixer, phpcs, composer:${{ inputs.composer-version }}
+
+      - name: Install Composer dependancies
+        run: composer install --no-progress --no-interaction
+
+      - name: Execute PHP CodeSniffer
+        run: phpcs -q
+
+  psalm:
+
+    name: Psalm - ${{ inputs.php-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: none
+          extensions: mbstring, intl, redis-phpredis/phpredis@6.0.2
+          tools: vimeo/psalm, composer:${{ inputs.composer-version }}
+        env:
+          REDIS_CONFIGURE_OPTS: --enable-redis-igbinary
+
+      - name: Install Composer dependancies
+        run: composer install --no-progress --no-interaction
+
+      - name: Execute Psalm
+        run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}


### PR DESCRIPTION
## Description

This fixes the CI workflow where Psalm now fails because PHP does not have Redis with IGBinary extension enabled (thus constant did not exist).

As a temporary measure, we copy-pasta the Static Analysis workflow from [dvsa/.github/workflows/php-static.yml](https://github.com/dvsa/.github/blob/main/.github/workflows/php-static.yml) and modify Setup PHP to compile Redis from source with support for IGBinary.

Related issue: https://dvsa.atlassian.net/browse/VOL-5559

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
